### PR TITLE
Add document version listing endpoint

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1384,18 +1384,17 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 [[package]]
 name = "rusty-s3"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f51a5a6b15f25d3e10c068039ee13befb6110fcb36c2b26317bcbdc23484d96"
+source = "git+https://github.com/dtkav/rusty-s3?branch=main#377ce9aca45336c4818782508e5dc5b43079a866"
 dependencies = [
  "base64 0.22.1",
  "hmac",
+ "jiff",
  "md-5",
  "percent-encoding",
  "quick-xml 0.37.2",
  "serde",
  "serde_json",
  "sha2",
- "time",
  "url",
  "zeroize",
 ]
@@ -1640,7 +1639,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
- "itoa",
  "js-sys",
  "num-conv",
  "powerfmt",

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -16,3 +16,6 @@ opt-level = 'z'  # Optimize for size
 lto = true       # Enable Link Time Optimization
 codegen-units = 1 # Further size optimization
 strip = true     # Strip symbols
+
+[patch.crates-io]
+rusty-s3 = { git = "https://github.com/dtkav/rusty-s3", branch = "main" }

--- a/crates/y-sweet-core/src/api_types.rs
+++ b/crates/y-sweet-core/src/api_types.rs
@@ -37,6 +37,20 @@ pub struct FileHistoryResponse {
     pub files: Vec<FileHistoryEntry>,
 }
 
+#[derive(Serialize)]
+pub struct DocumentVersionEntry {
+    #[serde(rename = "versionId")]
+    pub version_id: String,
+    #[serde(rename = "createdAt")]
+    pub created_at: u64,
+    #[serde(rename = "isLatest")]
+    pub is_latest: bool,
+}
+
+#[derive(Serialize)]
+pub struct DocumentVersionResponse {
+    pub versions: Vec<DocumentVersionEntry>,
+}
 
 /// Validate that the file hash is a valid SHA256 hash (64 hex characters)
 pub fn validate_file_hash(hash: &str) -> bool {

--- a/crates/y-sweet-core/src/store/mod.rs
+++ b/crates/y-sweet-core/src/store/mod.rs
@@ -1,8 +1,8 @@
 pub mod s3;
 
 use async_trait::async_trait;
-use thiserror::Error;
 use serde::Serialize;
+use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum StoreError {
@@ -24,7 +24,14 @@ pub type Result<T> = std::result::Result<T, StoreError>;
 pub struct FileInfo {
     pub key: String,
     pub size: u64,
-    pub last_modified: u64,  // timestamp in milliseconds
+    pub last_modified: u64, // timestamp in milliseconds
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct VersionInfo {
+    pub version_id: String,
+    pub last_modified: u64,
+    pub is_latest: bool,
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -54,11 +61,17 @@ pub trait Store: 'static {
             "This store does not support generating presigned URLs".to_string(),
         ))
     }
-    
+
     // List files with a common prefix and return their file info (key, size, last_modified)
     async fn list(&self, _prefix: &str) -> Result<Vec<FileInfo>> {
         Err(StoreError::UnsupportedOperation(
             "This store does not support listing files".to_string(),
+        ))
+    }
+
+    async fn list_versions(&self, _key: &str) -> Result<Vec<VersionInfo>> {
+        Err(StoreError::UnsupportedOperation(
+            "This store does not support listing versions".to_string(),
         ))
     }
 }
@@ -90,11 +103,17 @@ pub trait Store: Send + Sync {
             "This store does not support generating presigned URLs".to_string(),
         ))
     }
-    
+
     // List files with a common prefix and return their file info (key, size, last_modified)
     async fn list(&self, _prefix: &str) -> Result<Vec<FileInfo>> {
         Err(StoreError::UnsupportedOperation(
             "This store does not support listing files".to_string(),
+        ))
+    }
+
+    async fn list_versions(&self, _key: &str) -> Result<Vec<VersionInfo>> {
+        Err(StoreError::UnsupportedOperation(
+            "This store does not support listing versions".to_string(),
         ))
     }
 }


### PR DESCRIPTION
## Summary
- use patched rusty-s3 across workspace
- support listing object versions in storage layer
- expose new `/d/:doc_id/versions` endpoint

## Testing
- `cargo test --workspace --tests`

------
https://chatgpt.com/codex/tasks/task_e_687ac66b8e8c8321bd9f04be7ec60ebb