### PR TITLE
Serve Swagger UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Relay Server is a fork of [jamsocket/y-sweet](https://github.com/jamsocket/y-swe
  - Flexible deployment/isolation with single server or session‑per‑document model
  - Python SDK
  - Webhook Event Delivery
+ - OpenAPI documentation available at `/docs` (spec at `/openapi.yaml`)
 
 
 ## Self-hosting

--- a/crates/y-sweet/Cargo.toml
+++ b/crates/y-sweet/Cargo.toml
@@ -33,6 +33,8 @@ yrs = { version = "0.19.1" }
 yrs-kvstore = "0.3.0"
 bincode = "1.3.3"
 hex = "0.4.3"
+swagger-ui = "0.1.5"
+mime_guess = "2.0.5"
 
 [dev-dependencies]
 http = "1.1.0"


### PR DESCRIPTION
## Summary
- expose `/openapi.yaml` and Swagger UI endpoints
- show doc link in README

## Testing
- `cargo test --manifest-path crates/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_687ffd41edfc832192100ae0aa7d71c9