### PR TITLE
feat: log first receipt of a brand-new doc id

### DIFF
--- a/crates/relay/src/server.rs
+++ b/crates/relay/src/server.rs
@@ -523,6 +523,19 @@ impl Server {
         )
         .await?;
 
+        // First receipt of a brand-new doc: nothing in the store held state
+        // for this id. Logged with the authenticated user so surprise
+        // identities (e.g. republished deletions) are attributable from
+        // server logs alone.
+        if dwskv.sync_kv().created() {
+            tracing::info!(
+                doc_id = ?doc_id,
+                user = ?user,
+                channel = ?routing_channel_name,
+                "New doc created: first receipt of this id"
+            );
+        }
+
         // If channel is provided in token, store it in document metadata
         if let Some(channel_name) = routing_channel {
             dwskv.set_channel(&channel_name);

--- a/crates/y-sweet-core/src/sync_kv.rs
+++ b/crates/y-sweet-core/src/sync_kv.rs
@@ -117,6 +117,9 @@ pub struct SyncKv {
     created_at: Option<u64>,
     write_lease: Arc<Mutex<Option<WriteLease>>>,
     metadata: Arc<RwLock<Option<BTreeMap<String, ciborium::value::Value>>>>,
+    /// True when the backing store held no snapshot for this key at load -
+    /// i.e. this is the first time this server has seen the doc.
+    created: bool,
 }
 
 impl SyncKv {
@@ -129,6 +132,7 @@ impl SyncKv {
         let mut created_at = None;
         let mut metadata = None;
         let mut write_lease = None;
+        let mut created = false;
 
         let data = if let Some(store) = &store {
             let leased = store
@@ -166,6 +170,7 @@ impl SyncKv {
                     }
                 }
             } else {
+                created = true;
                 BTreeMap::new()
             }
         } else {
@@ -182,6 +187,7 @@ impl SyncKv {
             created_at,
             write_lease: Arc::new(Mutex::new(write_lease)),
             metadata: Arc::new(RwLock::new(metadata)),
+            created,
         })
     }
 
@@ -224,8 +230,15 @@ impl SyncKv {
             created_at,
             write_lease: Arc::new(Mutex::new(None)),
             metadata: Arc::new(RwLock::new(metadata)),
+            created: false,
         };
         Ok((inst, modified_at))
+    }
+
+    /// True when the backing store held no snapshot for this key at load -
+    /// the doc is brand new to this server.
+    pub fn created(&self) -> bool {
+        self.created
     }
 
     fn mark_dirty(&self) {


### PR DESCRIPTION
🍋: drafted by an AI assistant working with @petergaultney

While debugging deleted files that reappear across a ~40-user fleet, the recurring dead end was attribution: a resurrected file arrives under a brand-new doc id, and nothing server-side records who introduced an id or when - client logs would require access to every user's machine. This PR adds one log line at the moment a doc id first exists on the server, carrying the doc id, the authenticated user, and the routing channel.

Technical details follow.

## Change

`SyncKv::new` already distinguishes "store returned a snapshot" from "store had nothing for this key" - the latter is exactly first receipt. Surface it as `SyncKv::created()`, and in `build_doc` emit:

```
tracing::info!(doc_id = ?doc_id, user = ?user, channel = ?routing_channel_name, "New doc created: first receipt of this id");
```

`user` is the same value the existing "Loading doc" line and `DocumentUpdatedEvent` already carry.

## Caveats

- "Created" means new to this server's storage: a storage reset re-logs existing docs as new on their next load.
- The server has no notion of file paths (those live inside folder docs, which it treats as opaque), so investigations still resolve path -> doc id client-side, then grep server logs by id. In our zombie-file investigations the id was always in hand; the missing half was who/when, which this supplies.

## Testing

- `cargo check` clean (one pre-existing dead-code warning elsewhere in y-sweet-core, untouched).
- Not yet deployed anywhere. We self-host and plan to run this on our own server; happy to report back with field results if useful.
