### PR TITLE
feat: version gating, client-id declarations, and PUD-only update suppression

### DIFF
--- a/crates/relay.toml.example
+++ b/crates/relay.toml.example
@@ -6,6 +6,10 @@ url = "https://api.example.com"  # RELAY_SERVER_URL
 host = "0.0.0.0"                 # RELAY_SERVER_HOST
 port = 8080                      # PORT
 
+# When non-empty, doc websocket connections must report one of these plugin
+# versions (via the `v` query param). Older clients get 403. Empty = no gate.
+# allowed_client_versions = ["0.9.0"]
+
 [metrics]
 port = 9090                      # METRICS_PORT
 

--- a/crates/relay/src/client_versions.rs
+++ b/crates/relay/src/client_versions.rs
@@ -1,0 +1,302 @@
+//! Plugin version per Yjs client id, for annotating logs and gating access.
+//!
+//! Two sources, by strength:
+//!
+//! - **Declared**: the client's own statement of its id-version binding,
+//!   via either the `cid` upgrade query param (binding the id to the
+//!   connection's `v` param) or a `relayVersion` field inside its awareness
+//!   state payload. Minted by the id's owner, so it stays correct no matter
+//!   who relays it. Overrides everything.
+//! - **Inferred**: the `v` query param of the connection that *introduced*
+//!   the id - the first live (non-null, solo) awareness entry the server has
+//!   ever seen for it. An echo can only echo what the server already
+//!   broadcast, so the first introduction is causally the owner's own
+//!   connection. Immutable once set (an id is one session on one build), and
+//!   rendered with a `~` prefix so its weaker provenance is visible.
+//!
+//! Nothing else may feed this. Binding transport facts to the ids embedded in
+//! *updates* stamped the deliverer's version onto the minter (one resync
+//! re-stamped ~4,300 ids), and non-first awareness entries can be echoes.
+//!
+//! Ephemeral by design: versions describe live clients, so a restart forgets
+//! them - at the cost that sessions which re-introduce their ids inside
+//! full-map relays after a restart stay unversioned until they declare.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::RwLock;
+
+pub const UNKNOWN: &str = "-";
+
+#[derive(Default)]
+struct _State {
+    declared: HashMap<u64, String>,
+    inferred: HashMap<u64, String>,
+    seen: HashSet<u64>,
+}
+
+pub struct Observation<'a> {
+    pub client_id: u64,
+    pub declared: Option<&'a str>,
+    pub solo_live: bool,
+    pub connection_version: Option<&'a str>,
+}
+
+pub struct Recorded {
+    pub version: String,
+    pub previous: Option<String>,
+}
+
+#[derive(Default)]
+pub struct ClientVersions {
+    state: RwLock<_State>,
+}
+
+impl ClientVersions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn _declare(state: &mut _State, client_id: u64, version: &str) -> Option<Recorded> {
+        let previous = state.declared.insert(client_id, version.to_string());
+        if previous.as_deref() == Some(version) {
+            return None;
+        }
+
+        Some(Recorded {
+            version: version.to_string(),
+            previous,
+        })
+    }
+
+    pub fn declare(&self, client_id: u64, version: &str) -> Option<Recorded> {
+        let mut state = self.state.write().unwrap();
+        state.seen.insert(client_id);
+        Self::_declare(&mut state, client_id, version)
+    }
+
+    pub fn observe(&self, observation: Observation) -> Option<Recorded> {
+        let mut state = self.state.write().unwrap();
+        let never_seen = state.seen.insert(observation.client_id);
+
+        if let Some(declared) = observation.declared {
+            return Self::_declare(&mut state, observation.client_id, declared);
+        }
+
+        if !(observation.solo_live && never_seen) {
+            return None;
+        }
+        let version = observation.connection_version?;
+
+        state
+            .inferred
+            .insert(observation.client_id, version.to_string());
+        Some(Recorded {
+            version: format!("~{version}"),
+            previous: None,
+        })
+    }
+
+    fn _lookup(state: &_State, client_id: u64) -> Option<String> {
+        if let Some(declared) = state.declared.get(&client_id) {
+            return Some(declared.clone());
+        }
+
+        state
+            .inferred
+            .get(&client_id)
+            .map(|version| format!("~{version}"))
+    }
+
+    pub fn describe(&self, client_ids: &[u64]) -> String {
+        let state = self.state.read().unwrap();
+        let mut versions: Vec<String> = client_ids
+            .iter()
+            .filter_map(|client_id| Self::_lookup(&state, *client_id))
+            .collect();
+        versions.sort_unstable();
+        versions.dedup();
+
+        if versions.is_empty() {
+            return UNKNOWN.to_string();
+        }
+
+        versions.join(",")
+    }
+
+    pub fn snapshot(&self) -> Vec<(u64, String)> {
+        let state = self.state.read().unwrap();
+        let mut entries: Vec<(u64, String)> = state
+            .declared
+            .keys()
+            .chain(state.inferred.keys())
+            .filter_map(|client_id| {
+                Self::_lookup(&state, *client_id).map(|version| (*client_id, version))
+            })
+            .collect();
+        entries.sort_unstable_by_key(|(client_id, _)| *client_id);
+        entries.dedup_by_key(|(client_id, _)| *client_id);
+        entries
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn declared(client_id: u64, version: &str) -> Observation<'_> {
+        Observation {
+            client_id,
+            declared: Some(version),
+            solo_live: true,
+            connection_version: None,
+        }
+    }
+
+    fn introduced(client_id: u64, connection_version: &str) -> Observation<'_> {
+        Observation {
+            client_id,
+            declared: None,
+            solo_live: true,
+            connection_version: Some(connection_version),
+        }
+    }
+
+    #[test]
+    fn a_declared_version_reports_bare() {
+        let versions = ClientVersions::new();
+        versions.observe(declared(1, "0.9.1"));
+
+        assert_eq!(versions.describe(&[1]), "0.9.1");
+    }
+
+    #[test]
+    fn a_first_introduction_infers_with_visible_provenance() {
+        let versions = ClientVersions::new();
+        versions.observe(introduced(1, "0.9.0"));
+
+        assert_eq!(versions.describe(&[1]), "~0.9.0");
+    }
+
+    #[test]
+    fn an_echo_after_introduction_cannot_rebind() {
+        let versions = ClientVersions::new();
+        versions.observe(introduced(1, "0.9.0"));
+        assert!(versions.observe(introduced(1, "0.8.8")).is_none());
+
+        assert_eq!(versions.describe(&[1]), "~0.9.0");
+    }
+
+    #[test]
+    fn an_id_first_seen_in_a_relay_is_never_inferable() {
+        let versions = ClientVersions::new();
+        versions.observe(Observation {
+            client_id: 1,
+            declared: None,
+            solo_live: false,
+            connection_version: Some("0.9.0"),
+        });
+        assert!(versions.observe(introduced(1, "0.9.0")).is_none());
+
+        assert_eq!(versions.describe(&[1]), UNKNOWN);
+    }
+
+    #[test]
+    fn a_declaration_overrides_an_inference() {
+        let versions = ClientVersions::new();
+        versions.observe(introduced(1, "0.9.0"));
+        versions.observe(declared(1, "0.9.1"));
+
+        assert_eq!(versions.describe(&[1]), "0.9.1");
+    }
+
+    #[test]
+    fn an_inference_never_overrides_a_declaration() {
+        let versions = ClientVersions::new();
+        versions.observe(declared(1, "0.9.1"));
+        versions.observe(introduced(1, "0.8.8"));
+
+        assert_eq!(versions.describe(&[1]), "0.9.1");
+    }
+
+    #[test]
+    fn a_connection_without_a_version_cannot_infer() {
+        let versions = ClientVersions::new();
+        assert!(versions
+            .observe(Observation {
+                client_id: 1,
+                declared: None,
+                solo_live: true,
+                connection_version: None,
+            })
+            .is_none());
+
+        assert_eq!(versions.describe(&[1]), UNKNOWN);
+    }
+
+    #[test]
+    fn repeated_declarations_log_once() {
+        let versions = ClientVersions::new();
+        assert!(versions.observe(declared(1, "0.9.1")).is_some());
+        assert!(versions.observe(declared(1, "0.9.1")).is_none());
+    }
+
+    #[test]
+    fn a_merged_update_across_builds_names_both() {
+        let versions = ClientVersions::new();
+        versions.observe(declared(1, "0.8.9"));
+        versions.observe(introduced(2, "0.9.0"));
+
+        assert_eq!(versions.describe(&[1, 2]), "0.8.9,~0.9.0");
+    }
+
+    #[test]
+    fn unrecorded_clients_do_not_mask_a_known_one() {
+        let versions = ClientVersions::new();
+        versions.observe(declared(1, "0.9.1"));
+
+        assert_eq!(versions.describe(&[1, 999]), "0.9.1");
+    }
+
+    #[test]
+    fn no_clients_at_all_reads_as_unknown() {
+        let versions = ClientVersions::new();
+
+        assert_eq!(versions.describe(&[]), UNKNOWN);
+    }
+
+    #[test]
+    fn a_pre_joined_declaration_reports_bare() {
+        let versions = ClientVersions::new();
+        versions.declare(1, "0.9.1");
+
+        assert_eq!(versions.describe(&[1]), "0.9.1");
+    }
+
+    #[test]
+    fn a_pre_joined_declaration_blocks_later_inference() {
+        let versions = ClientVersions::new();
+        versions.declare(1, "0.9.1");
+        assert!(versions.observe(introduced(1, "0.8.8")).is_none());
+
+        assert_eq!(versions.describe(&[1]), "0.9.1");
+    }
+
+    #[test]
+    fn a_matching_payload_declaration_after_a_pre_join_logs_nothing() {
+        let versions = ClientVersions::new();
+        assert!(versions.declare(1, "0.9.1").is_some());
+        assert!(versions.observe(declared(1, "0.9.1")).is_none());
+    }
+
+    #[test]
+    fn a_snapshot_lists_both_sources_in_id_order() {
+        let versions = ClientVersions::new();
+        versions.observe(introduced(20, "0.9.0"));
+        versions.observe(declared(10, "0.9.1"));
+
+        assert_eq!(
+            versions.snapshot(),
+            vec![(10, "0.9.1".to_string()), (20, "~0.9.0".to_string()),]
+        );
+    }
+}

--- a/crates/relay/src/edit_author.rs
+++ b/crates/relay/src/edit_author.rs
@@ -1,0 +1,170 @@
+//! Identify the Yjs client ids behind an update.
+//!
+//! Two traps in reading those client ids, both of which fail by reporting no
+//! author rather than a wrong one:
+//!
+//! 1. Use `Update::state_vector_lower`, never `state_vector`. The latter is an
+//!    upper bound over blocks contiguous from clock 0, so it drops any client
+//!    whose first block in the update has a nonzero clock - which is every
+//!    update after a client's first.
+//! 2. Insertions and deletions live in different places. A deletion creates no
+//!    blocks, so a delete-only update has an empty state vector by any measure
+//!    and is attributable only through `delete_set`.
+
+use std::collections::HashSet;
+use yrs::updates::decoder::Decode;
+use yrs::Update;
+
+fn _clients_in(update: &Update) -> HashSet<u64> {
+    update
+        .state_vector_lower()
+        .iter()
+        .map(|(client_id, _)| client_id.get())
+        .chain(
+            update
+                .delete_set()
+                .iter()
+                .map(|(client_id, _)| client_id.get()),
+        )
+        .collect()
+}
+
+/// The yjs client ids an update came from, ascending.
+pub fn clients_in_update(update: &[u8]) -> Vec<u64> {
+    let Ok(decoded) = Update::decode_v1(update) else {
+        return Vec::new();
+    };
+
+    let mut ids: Vec<u64> = _clients_in(&decoded).into_iter().collect();
+    ids.sort_unstable();
+    ids
+}
+
+/// True when every client in the update is server-authored (53-bit yrs id,
+/// >= 2^32). PUD registration writes are the main case: the server mutates
+/// the doc's `users` map under its own client id, which fires
+/// `observe_update_v1` and would otherwise produce a webhook for internal
+/// bookkeeping that no human produced.
+pub fn is_server_only_update(update: &[u8]) -> bool {
+    let Ok(decoded) = Update::decode_v1(update) else {
+        return false;
+    };
+
+    let ids = _clients_in(&decoded);
+    !ids.is_empty() && ids.iter().all(|id| *id >= (1u64 << 32))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use yrs::{Map, ReadTxn, Text, Transact};
+
+    fn update_from(doc: &yrs::Doc, text: &str) -> Vec<u8> {
+        let body = doc.get_or_insert_text("body");
+        let before = doc.transact().state_vector();
+        {
+            let mut txn = doc.transact_mut();
+            body.push(&mut txn, text);
+        }
+        doc.transact().encode_state_as_update_v1(&before)
+    }
+
+    #[test]
+    fn clients_in_update_names_the_author() {
+        let a = yrs::Doc::new();
+        let update = update_from(&a, "hello");
+
+        assert_eq!(clients_in_update(&update), vec![a.client_id().get()]);
+        assert_eq!(clients_in_update(b"not an update"), Vec::<u64>::new());
+    }
+
+    #[test]
+    fn a_map_insert_still_names_its_client() {
+        let doc = yrs::Doc::new();
+        let map = doc.get_or_insert_map("filemeta_v0");
+        let before = doc.transact().state_vector();
+        {
+            let mut txn = doc.transact_mut();
+            map.insert(&mut txn, "notes/x.md", "guid-x");
+        }
+        let update = doc.transact().encode_state_as_update_v1(&before);
+
+        assert_eq!(clients_in_update(&update), vec![doc.client_id().get()]);
+    }
+
+    #[test]
+    fn a_map_removal_names_the_client_that_deleted() {
+        let doc = yrs::Doc::new();
+        let map = doc.get_or_insert_map("filemeta_v0");
+        {
+            let mut txn = doc.transact_mut();
+            map.insert(&mut txn, "notes/x.md", "guid-x");
+        }
+        let before = doc.transact().state_vector();
+        {
+            let mut txn = doc.transact_mut();
+            map.remove(&mut txn, "notes/x.md");
+        }
+        let update = doc.transact().encode_state_as_update_v1(&before);
+
+        assert_eq!(clients_in_update(&update), vec![doc.client_id().get()]);
+    }
+
+    #[test]
+    fn a_later_update_still_names_its_client() {
+        let doc = yrs::Doc::new();
+        let map = doc.get_or_insert_map("filemeta_v0");
+        {
+            let mut txn = doc.transact_mut();
+            map.insert(&mut txn, "notes/first.md", "guid-1");
+        }
+        let before = doc.transact().state_vector();
+        {
+            let mut txn = doc.transact_mut();
+            map.insert(&mut txn, "notes/second.md", "guid-2");
+        }
+        let update = doc.transact().encode_state_as_update_v1(&before);
+
+        assert!(
+            Update::decode_v1(&update)
+                .unwrap()
+                .state_vector()
+                .is_empty(),
+            "guards the reason for state_vector_lower"
+        );
+        assert_eq!(clients_in_update(&update), vec![doc.client_id().get()]);
+    }
+
+    #[test]
+    fn is_server_only_detects_53_bit_ids() {
+        let server_doc = yrs::Doc::with_client_id((1u64 << 32) + 42);
+        let update = update_from(&server_doc, "pud write");
+        assert!(is_server_only_update(&update));
+
+        let user_doc = yrs::Doc::with_client_id(42);
+        let user_update = update_from(&user_doc, "human edit");
+        assert!(!is_server_only_update(&user_update));
+    }
+
+    #[test]
+    fn mixed_server_and_user_ids_is_not_server_only() {
+        let user = yrs::Doc::with_client_id(42);
+        let server = yrs::Doc::with_client_id((1u64 << 32) + 1);
+        let from_user = update_from(&user, "user");
+        let from_server = update_from(&server, "server");
+
+        let merged = yrs::Doc::new();
+        {
+            let mut txn = merged.transact_mut();
+            txn.apply_update(Update::decode_v1(&from_user).unwrap())
+                .unwrap();
+            txn.apply_update(Update::decode_v1(&from_server).unwrap())
+                .unwrap();
+        }
+        let combined = merged
+            .transact()
+            .encode_state_as_update_v1(&yrs::StateVector::default());
+
+        assert!(!is_server_only_update(&combined));
+    }
+}

--- a/crates/relay/src/lib.rs
+++ b/crates/relay/src/lib.rs
@@ -1,11 +1,13 @@
 #![doc = include_str!("../README.md")]
 
 pub mod cli;
+pub mod client_versions;
 pub mod convert;
 pub mod doc_inspect;
 pub mod doc_lifecycle;
 pub mod doc_restore;
 pub mod doc_versions;
+pub mod edit_author;
 pub mod migrations;
 pub mod server;
 pub mod stores;

--- a/crates/relay/src/main.rs
+++ b/crates/relay/src/main.rs
@@ -928,7 +928,8 @@ async fn main() -> Result<()> {
                 config.server.doc_gc,
                 webhook_configs,
             )
-            .await?;
+            .await?
+            .with_allowed_client_versions(config.server.allowed_client_versions);
 
             let redact_errors = config.server.redact_errors;
             let server = Arc::new(server);

--- a/crates/relay/src/server.rs
+++ b/crates/relay/src/server.rs
@@ -1,4 +1,6 @@
+use crate::client_versions::{self, ClientVersions};
 use crate::doc_lifecycle::{AttachGuard, AttachKind, DocRegistry, LifecycleConfig};
+use crate::edit_author;
 use anyhow::{anyhow, Result};
 use axum::{
     body::Bytes,
@@ -22,7 +24,12 @@ use futures::{Sink, SinkExt, Stream, StreamExt, TryStreamExt};
 use serde::Deserialize;
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
-use std::{io::Write, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    io::Write,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
 use tempfile::NamedTempFile;
 use tokio::{
     net::TcpListener,
@@ -58,6 +65,8 @@ const PING_EVERY: Duration = Duration::from_secs(20);
 /// would-be keepalive reap. Observe-only: the connection is never closed for
 /// this; the metric exists to measure whether enforcement would be safe.
 const PONG_TIMEOUT: Duration = Duration::from_secs(40);
+
+const DENIAL_LOG_INTERVAL: Duration = Duration::from_secs(1800);
 
 #[derive(Clone, Debug)]
 pub struct AllowedHost {
@@ -238,6 +247,17 @@ pub struct Server {
     event_dispatcher: Option<Arc<dyn EventDispatcher>>,
     sync_protocol_event_sender: Arc<SyncProtocolEventSender>,
     metrics: Arc<RelayMetrics>,
+    allowed_client_versions: HashSet<String>,
+    denial_log_throttle: Mutex<HashMap<String, DenialLogState>>,
+    client_versions: Arc<ClientVersions>,
+}
+
+type ClientVersionRecorder =
+    Arc<dyn Fn(&y_sweet_core::doc_connection::AwarenessEntryFacts) + Send + Sync>;
+
+struct DenialLogState {
+    last_logged: Instant,
+    suppressed: u64,
 }
 
 impl Server {
@@ -308,7 +328,89 @@ impl Server {
             event_dispatcher,
             sync_protocol_event_sender,
             metrics,
+            allowed_client_versions: HashSet::new(),
+            denial_log_throttle: Mutex::new(HashMap::new()),
+            client_versions: Arc::new(ClientVersions::new()),
         })
+    }
+
+    pub fn with_allowed_client_versions(
+        mut self,
+        versions: impl IntoIterator<Item = String>,
+    ) -> Self {
+        self.allowed_client_versions = versions.into_iter().collect();
+        if !self.allowed_client_versions.is_empty() {
+            tracing::warn!(
+                "Requiring client version in {:?} for doc websocket access",
+                self.allowed_client_versions
+            );
+        }
+        self
+    }
+
+    fn denial_log_permit(&self, user: &str) -> Option<u64> {
+        let mut throttle = self.denial_log_throttle.lock().unwrap();
+        match throttle.get_mut(user) {
+            Some(state) if state.last_logged.elapsed() < DENIAL_LOG_INTERVAL => {
+                state.suppressed += 1;
+                None
+            }
+            Some(state) => {
+                let suppressed = state.suppressed;
+                state.last_logged = Instant::now();
+                state.suppressed = 0;
+                Some(suppressed)
+            }
+            None => {
+                throttle.insert(
+                    user.to_string(),
+                    DenialLogState {
+                        last_logged: Instant::now(),
+                        suppressed: 0,
+                    },
+                );
+                Some(0)
+            }
+        }
+    }
+
+    fn check_client_version(
+        &self,
+        user: Option<&str>,
+        version: Option<&str>,
+    ) -> Result<(), AppError> {
+        let Some(user) = user else {
+            return Ok(());
+        };
+        if self.allowed_client_versions.is_empty() {
+            return Ok(());
+        }
+
+        match version {
+            Some(v) if self.allowed_client_versions.contains(v) => Ok(()),
+            _ => {
+                if let Some(suppressed) = self.denial_log_permit(user) {
+                    tracing::warn!(
+                        user = %user,
+                        version = %version.unwrap_or("none"),
+                        allowed = %self
+                            .allowed_client_versions
+                            .iter()
+                            .cloned()
+                            .collect::<Vec<_>>()
+                            .join(","),
+                        suppressed,
+                        interval_secs = DENIAL_LOG_INTERVAL.as_secs(),
+                        "Blocked user on client version"
+                    );
+                }
+                Err(AppError::auth(
+                    StatusCode::FORBIDDEN,
+                    anyhow!("This plugin version is temporarily blocked from sync; run witchdoctor to upgrade"),
+                    "client_version_blocked",
+                ))
+            }
+        }
     }
 
     /// Close every doc WebSocket: each socket loop breaks, sends its
@@ -486,23 +588,22 @@ impl Server {
                         }
                     }
 
-                    // Log the full event payload as JSON after user assignment
-                    match serde_json::to_string(&event) {
-                        Ok(json_str) => {
-                            tracing::info!("Document updated event dispatched: {}", json_str);
-                        }
-                        Err(e) => {
-                            tracing::info!(
-                                "Document updated event dispatched for doc_id: {} (JSON serialization failed: {})",
-                                event.doc_id, e
-                            );
-                        }
+                    // PUD registration and payload-driven PUD writes mutate
+                    // the doc under the server's own 53-bit client id. These
+                    // fire observe_update_v1 like any edit, but are internal
+                    // bookkeeping - not human-produced content changes.
+                    if event
+                        .update
+                        .as_deref()
+                        .is_some_and(edit_author::is_server_only_update)
+                    {
+                        let envelope =
+                            EventEnvelope::new(routing_channel_for_callback.clone(), event);
+                        dispatcher.send_event(envelope);
+                        return;
                     }
 
-                    // Step 1: Create the envelope with predetermined routing channel
                     let envelope = EventEnvelope::new(routing_channel_for_callback.clone(), event);
-
-                    // Step 2: Send via dispatcher
                     dispatcher.send_event(envelope);
                 }) as y_sweet_core::webhook::WebhookCallback)
             } else {
@@ -884,6 +985,17 @@ impl Server {
 #[derive(Deserialize)]
 struct HandlerParams {
     token: Option<String>,
+    v: Option<String>,
+    cid: Option<String>,
+}
+
+impl HandlerParams {
+    fn declared_client_ids(&self) -> Vec<u64> {
+        self.cid
+            .as_deref()
+            .map(|cid| cid.split(',').filter_map(|id| id.parse().ok()).collect())
+            .unwrap_or_default()
+    }
 }
 
 async fn get_doc_as_update(
@@ -962,6 +1074,7 @@ async fn update_doc_inner(
     Ok(StatusCode::OK.into_response())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn handle_socket_upgrade_with_channel_and_user(
     ws: WebSocketUpgrade,
     Path(doc_id): Path<String>,
@@ -969,6 +1082,8 @@ async fn handle_socket_upgrade_with_channel_and_user(
     routing_channel: Option<String>,
     user: Option<String>,
     token: Option<String>,
+    version: Option<String>,
+    declared_client_ids: Vec<u64>,
     State(server_state): State<Arc<Server>>,
 ) -> Result<Response, AppError> {
     server_state
@@ -995,15 +1110,66 @@ async fn handle_socket_upgrade_with_channel_and_user(
         .attach_doc(&doc_id, AttachKind::Socket, routing_channel, user)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
-    // Socket loops watch the doc-close token (a child of the server token)
-    // so shutdown can close them ahead of the graceful drain.
     let cancellation_token = server_state.doc_close_token.clone();
     let sync_protocol_event_sender = server_state.sync_protocol_event_sender.clone();
     let metrics = server_state.metrics.clone();
     let doc_id_clone = doc_id.clone();
+    let client_versions = server_state.client_versions.clone();
+    let doc_id_for_recorder = doc_id.clone();
+    for client_id in &declared_client_ids {
+        let client_id = *client_id;
+        let Some(v) = version.as_deref() else { break };
 
-    // The guard moves into the upgrade closure: an abandoned upgrade
-    // detaches via RAII.
+        if let Some(recorded) = client_versions.declare(client_id, v) {
+            tracing::debug!(
+                client_id,
+                version = %recorded.version,
+                previous = %recorded.previous.as_deref().unwrap_or(client_versions::UNKNOWN),
+                doc_id = %doc_id,
+                "Recorded client version"
+            );
+        }
+        if let (Some(user), true) = (user_for_pud.as_deref(), client_id >> 53 == 0) {
+            let awareness = guard.awareness();
+            let awareness = awareness.read().unwrap();
+            y_sweet_core::doc_connection::DocConnection::register_pud_client_id_on_doc(
+                awareness.doc(),
+                user,
+                yrs::block::ClientID::new(client_id),
+            );
+        }
+    }
+    let record_client_version: ClientVersionRecorder = Arc::new(move |facts| {
+        let mut recordings = vec![(
+            facts.client_id,
+            client_versions.observe(client_versions::Observation {
+                client_id: facts.client_id,
+                declared: facts.declared_version.as_deref(),
+                solo_live: facts.solo_live,
+                connection_version: version.as_deref(),
+            }),
+        )];
+        if let Some(declared) = facts.declared_version.as_deref() {
+            recordings.extend(
+                facts
+                    .extra_client_ids
+                    .iter()
+                    .map(|extra| (*extra, client_versions.declare(*extra, declared))),
+            );
+        }
+        for (client_id, recorded) in recordings {
+            let Some(recorded) = recorded else { continue };
+
+            tracing::debug!(
+                client_id,
+                version = %recorded.version,
+                previous = %recorded.previous.as_deref().unwrap_or("-"),
+                doc_id = %doc_id_for_recorder,
+                "Recorded client version"
+            );
+        }
+    });
+
     Ok(ws.on_upgrade(move |socket| {
         handle_socket(
             socket,
@@ -1015,6 +1181,7 @@ async fn handle_socket_upgrade_with_channel_and_user(
             sync_protocol_event_sender,
             doc_id_clone,
             metrics,
+            record_client_version,
         )
     }))
 }
@@ -1088,6 +1255,7 @@ async fn handle_socket_upgrade_deprecated(
     );
     let (authorization, channel, user) =
         verify_socket_token(&server_state, &doc_id, params.token.as_deref())?;
+    server_state.check_client_version(user.as_deref(), params.v.as_deref())?;
 
     handle_socket_upgrade_with_channel_and_user(
         ws,
@@ -1095,7 +1263,9 @@ async fn handle_socket_upgrade_deprecated(
         authorization,
         channel,
         user,
-        params.token.clone(), // Pass the token from query params
+        params.token.clone(),
+        params.v.clone(),
+        params.declared_client_ids(),
         State(server_state),
     )
     .await
@@ -1119,6 +1289,7 @@ async fn handle_socket_upgrade_full_path(
 
     let (authorization, channel, user) =
         verify_socket_token(&server_state, &doc_id, params.token.as_deref())?;
+    server_state.check_client_version(user.as_deref(), params.v.as_deref())?;
 
     handle_socket_upgrade_with_channel_and_user(
         ws,
@@ -1126,12 +1297,15 @@ async fn handle_socket_upgrade_full_path(
         authorization,
         channel,
         user,
-        params.token.clone(), // Pass the token from query params
+        params.token.clone(),
+        params.v.clone(),
+        params.declared_client_ids(),
         State(server_state),
     )
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn handle_socket(
     socket: WebSocket,
     guard: AttachGuard,
@@ -1142,6 +1316,7 @@ async fn handle_socket(
     sync_protocol_event_sender: Arc<SyncProtocolEventSender>,
     doc_id: String,
     metrics: Arc<RelayMetrics>,
+    record_client_version: ClientVersionRecorder,
 ) {
     let (sink, stream) = socket.split();
     handle_socket_inner(
@@ -1155,6 +1330,7 @@ async fn handle_socket(
         sync_protocol_event_sender,
         doc_id,
         metrics,
+        record_client_version,
     )
     .await
 }
@@ -1173,6 +1349,7 @@ async fn handle_socket_inner<S, T, E>(
     sync_protocol_event_sender: Arc<SyncProtocolEventSender>,
     doc_id: String,
     metrics: Arc<RelayMetrics>,
+    record_client_version: ClientVersionRecorder,
 ) where
     S: Sink<Message> + Send + Unpin + 'static,
     T: Stream<Item = Result<Message, E>> + Unpin,
@@ -1248,6 +1425,10 @@ async fn handle_socket_inner<S, T, E>(
         },
     );
     conn.set_sync_kv(sync_kv);
+    conn.set_doc_id(doc_id.clone());
+    conn.set_on_client_version(Box::new(move |facts| {
+        record_client_version(facts);
+    }));
     if let Some(user) = user {
         conn.set_user(user);
     }
@@ -3566,6 +3747,7 @@ mod test {
                 Arc::new(SyncProtocolEventSender::new()),
                 "test_doc".to_string(),
                 metrics.clone(),
+                Arc::new(|_| {}),
             ));
 
             SocketHarness {

--- a/crates/y-sweet-core/src/config.rs
+++ b/crates/y-sweet-core/src/config.rs
@@ -299,6 +299,13 @@ pub struct ServerConfig {
 
     #[serde(default = "default_redact_errors")]
     pub redact_errors: bool,
+
+    /// When non-empty, doc websocket connections must report one of these
+    /// plugin versions (`v` query param, sent by clients >= 0.8.8);
+    /// anything else - including clients too old to report - gets 403.
+    /// Server tokens are exempt. Empty = no version gating.
+    #[serde(default)]
+    pub allowed_client_versions: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -590,6 +597,7 @@ impl Default for ServerConfig {
             checkpoint_freq_seconds: default_checkpoint_freq_seconds(),
             doc_gc: default_doc_gc(),
             redact_errors: default_redact_errors(),
+            allowed_client_versions: Vec::new(),
         }
     }
 }
@@ -1214,5 +1222,35 @@ public_key = "test-public-key"
         let (key, types) = parse_auth_env_value("abc123base64key==").unwrap();
         assert_eq!(key, "abc123base64key==");
         assert_eq!(types, default_allowed_token_types());
+    }
+
+    #[test]
+    fn allowed_client_versions_are_optional() {
+        let config: Config = toml::from_str(
+            r#"
+[server]
+url = "https://example.com"
+"#,
+        )
+        .expect("a config with no allowed_client_versions must still parse");
+
+        assert!(config.server.allowed_client_versions.is_empty());
+    }
+
+    #[test]
+    fn allowed_client_versions_parse() {
+        let config: Config = toml::from_str(
+            r#"
+[server]
+url = "https://example.com"
+allowed_client_versions = ["0.9.3", "0.9.2"]
+"#,
+        )
+        .expect("config with allowed_client_versions must parse");
+
+        assert_eq!(
+            config.server.allowed_client_versions,
+            vec!["0.9.3", "0.9.2"]
+        );
     }
 }

--- a/crates/y-sweet-core/src/doc_connection.rs
+++ b/crates/y-sweet-core/src/doc_connection.rs
@@ -34,6 +34,51 @@ type Callback = Arc<dyn Fn(&[u8]) + 'static>;
 #[cfg(feature = "sync")]
 type Callback = Arc<dyn Fn(&[u8]) + 'static + Send + Sync>;
 
+/// Facts extracted from one awareness entry, before any trust decision.
+/// Everything here except `solo_live` comes from the entry's own state
+/// payload, which is minted by the entry's owner and survives relaying.
+pub struct AwarenessEntryFacts {
+    pub client_id: u64,
+    pub declared_version: Option<String>,
+    pub user_name: Option<String>,
+    pub user_id: Option<String>,
+    pub extra_client_ids: Vec<u64>,
+    pub solo_live: bool,
+}
+
+impl AwarenessEntryFacts {
+    fn from_entry(client_id: u64, json: &str, solo: bool) -> Self {
+        let live = json.trim() != "null";
+        let state = serde_json::from_str::<serde_json::Value>(json).ok();
+        let user = state.as_ref().and_then(|s| s.get("user"));
+        Self {
+            client_id,
+            declared_version: state
+                .as_ref()
+                .and_then(|s| s.get("relayVersion"))
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+            user_name: user
+                .and_then(|u| u.get("name"))
+                .and_then(|n| n.as_str())
+                .map(str::to_string),
+            user_id: user
+                .and_then(|u| u.get("id"))
+                .and_then(|i| i.as_str())
+                .map(str::to_string),
+            extra_client_ids: state
+                .as_ref()
+                .and_then(|s| s.get("relayClientIds"))
+                .and_then(|ids| ids.as_array())
+                .map(|ids| ids.iter().filter_map(|id| id.as_u64()).collect())
+                .unwrap_or_default(),
+            solo_live: solo && live,
+        }
+    }
+}
+
+type ClientVersionCallback = Box<dyn Fn(&AwarenessEntryFacts) + Send + Sync>;
+
 const SYNC_STATUS_MESSAGE: u8 = 102;
 
 pub struct DocConnection {
@@ -63,6 +108,10 @@ pub struct DocConnection {
     /// Authenticated user identity from the connection token.
     /// When set, the server will register new client_ids under this user in the "users" map.
     user: Option<String>,
+
+    doc_id: Option<String>,
+
+    on_client_version: Option<ClientVersionCallback>,
 }
 
 impl DocConnection {
@@ -206,11 +255,13 @@ impl DocConnection {
             authorization,
             callback,
             client_id: OnceLock::new(),
+            on_client_version: None,
             closed,
             event_subscriptions: Arc::new(RwLock::new(HashSet::new())),
             expiration_time,
             sync_kv: None,
             user: None,
+            doc_id: None,
         }
     }
 
@@ -222,6 +273,14 @@ impl DocConnection {
     /// Set the authenticated user identity for server-driven PUD registration.
     pub fn set_user(&mut self, user: String) {
         self.user = Some(user);
+    }
+
+    pub fn set_doc_id(&mut self, doc_id: String) {
+        self.doc_id = Some(doc_id);
+    }
+
+    pub fn set_on_client_version(&mut self, callback: ClientVersionCallback) {
+        self.on_client_version = Some(callback);
     }
 
     /// Snapshot the current state vector's client_ids (for before/after comparison).
@@ -240,11 +299,6 @@ impl DocConnection {
         awareness: &Awareness,
         sv_before: &std::collections::HashSet<ClientID>,
     ) {
-        let user_id = match &self.user {
-            Some(u) => u,
-            None => return,
-        };
-
         let sv_after = awareness.doc().transact().state_vector();
 
         let new_ids: Vec<ClientID> = sv_after
@@ -262,6 +316,10 @@ impl DocConnection {
             return;
         }
 
+        let Some(user_id) = &self.user else {
+            return;
+        };
+
         let doc = awareness.doc();
 
         for client_id in new_ids {
@@ -269,9 +327,7 @@ impl DocConnection {
         }
     }
 
-    /// Register a client_id in the "users" PermanentUserData map on the document.
-    /// Takes a Doc reference directly to avoid re-locking awareness.
-    fn register_pud_client_id_on_doc(doc: &yrs::Doc, user_id: &str, client_id: ClientID) {
+    pub fn register_pud_client_id_on_doc(doc: &yrs::Doc, user_id: &str, client_id: ClientID) {
         // get_or_insert_map takes a write txn internally, call before any read txn.
         let users_map = doc.get_or_insert_map("users");
 
@@ -417,11 +473,31 @@ impl DocConnection {
                 protocol.handle_awareness_query(&awareness)
             }
             Message::Awareness(update) => {
+                let solo = update.clients.len() == 1;
+                let facts: Vec<AwarenessEntryFacts> = update
+                    .clients
+                    .iter()
+                    .map(|(client_id, entry)| {
+                        AwarenessEntryFacts::from_entry(client_id.get(), &entry.json, solo)
+                    })
+                    .collect();
+                if let Some(callback) = &self.on_client_version {
+                    for entry_facts in &facts {
+                        callback(entry_facts);
+                    }
+                }
+                // PUD registration from payload user.id was here but caused a
+                // sync regression: the write lock + transact_mut per awareness
+                // message serialized against the sync path on reconnect. The
+                // cid upgrade path already registers declaring clients in PUD
+                // outside the message loop; delivery-time registration covers
+                // legacy clients. The awareness path was defense-in-depth only.
                 if update.clients.len() == 1 {
                     let client_id = update.clients.keys().next().unwrap();
                     self.client_id.get_or_init(|| *client_id);
                 } else {
                     tracing::warn!(
+                        doc_id = ?self.doc_id,
                         user = ?self.user,
                         connection_client_id = ?self.client_id.get(),
                         update_client_ids = ?update.clients.keys().collect::<Vec<_>>(),


### PR DESCRIPTION
## Summary

Adds three server-side capabilities for self-hosters managing a fleet of Relay plugin installations:

- **Plugin version gating** (`allowed_client_versions`): doc websocket connections from user-claimed tokens must report a version in the configured allowlist, or get 403. Server tokens are exempt. Empty list (default) disables gating. Denial warns are throttled to one log line per user per 30 minutes.

- **Client-id declarations** (`cid` query param + `relayClientIds` awareness field): plugins can declare which Yjs client ids they mint edits under (e.g. a merge-recovery working copy uses a separate local doc with its own client id). The server records these in PUD at websocket upgrade and tracks their plugin version via awareness payloads. This enables accurate version attribution even for edits that arrive through intermediary docs.

- **PUD-only update suppression**: updates authored entirely by the server's own 53-bit client ids (PermanentUserData registration writes) now skip webhook dispatch. These are internal bookkeeping, not human-produced content changes, and firing webhooks for them creates unnecessary git-sync churn.

## Details

### Version gating

A new `allowed_client_versions` field on `[server]` in relay.toml. When non-empty, the `v` query param on websocket upgrade is checked against it. Clients too old to report a version are blocked. The gate is enforced on both the deprecated and full-path websocket upgrade handlers.

### Client-id declarations

The `cid` query param accepts a comma-separated list of Yjs client ids. At websocket upgrade, each declared id gets:
1. Its version recorded (from the connection's `v` param)
2. PUD registration (binding the client id to the authenticated user in the doc's `users` map)

The `relayClientIds` awareness payload field is also consumed: when a client broadcasts additional ids it mints edits under, those are recorded with the same declared version.

### Version tracking infrastructure

`client_versions.rs` implements a two-tier trust model:
- **Declared**: the client's own statement via `cid` param or `relayVersion` awareness payload. Overwrites previous values.
- **Inferred**: first-introduction binding from a solo awareness entry's connection version. Immutable once set, rendered with `~` prefix.

Updates never bind versions (the deliverer is not the minter). Non-first awareness entries are tracked as "seen" but never inferred from.

### PUD suppression

`is_server_only_update` checks whether all client ids in an update are >= 2^32 (server-authored). These updates still get dispatched as event envelopes (so sync protocol events fire), but skip the webhook path.

## Relationship to the other open PRs

Independent - this branches straight off `main` and contains only behavior changes. No log-level changes here; those are all in #26.

| PR | Contains | Independent? |
|---|---|---|
| #26 | log volume: demotions, connection lifecycle logs, identity on warns | yes |
| **#23 (this one)** | behavior: version gating, cid declarations, PUD suppression | yes |
| #24 | semantic logging, gated on a config flag that defaults to off | no - needs #23 |
| #25 | attributed-content endpoint | yes |

#26 and this PR both touch the `Received awareness update with more than one client` line - #26 changes its level, this one adds a `doc_id` field. Whichever merges second takes a one-line textual conflict; there is no semantic disagreement.

## Test plan

- [ ] Verify websocket connections without `v` param are rejected when `allowed_client_versions` is non-empty
- [ ] Verify server tokens bypass the version gate
- [ ] Verify `cid` param registers PUD entries at upgrade
- [ ] Verify PUD-only updates don't fire webhooks
- [ ] Verify empty `allowed_client_versions` (default) disables gating
- [ ] 260 tests pass (`cargo test` in `crates/`)

