### PR TITLE
feat: semantic logging - edit attribution, debounce, vpath resolution

### DIFF
--- a/crates/relay.toml.example
+++ b/crates/relay.toml.example
@@ -6,6 +6,10 @@ url = "https://api.example.com"  # RELAY_SERVER_URL
 host = "0.0.0.0"                 # RELAY_SERVER_HOST
 port = 8080                      # PORT
 
+# When non-empty, doc websocket connections must report one of these plugin
+# versions (via the `v` query param). Older clients get 403. Empty = no gate.
+# allowed_client_versions = ["0.9.0"]
+
 [metrics]
 port = 9090                      # METRICS_PORT
 

--- a/crates/relay.toml.example
+++ b/crates/relay.toml.example
@@ -10,6 +10,15 @@ port = 8080                      # PORT
 # versions (via the `v` query param). Older clients get 403. Empty = no gate.
 # allowed_client_versions = ["0.9.0"]
 
+# Enables edit attribution logging, vpath resolution, folder membership
+# change tracking, the /client-versions endpoint, and user display names
+# in log lines. Default false.
+# semantic_logging = true
+
+# Display names for log readability. Only used when semantic_logging = true.
+# [server.user_names]
+# "relay_user_id_here" = "Ada Lovelace"
+
 [metrics]
 port = 9090                      # METRICS_PORT
 

--- a/crates/relay/src/client_versions.rs
+++ b/crates/relay/src/client_versions.rs
@@ -1,0 +1,302 @@
+//! Plugin version per Yjs client id, for annotating logs and gating access.
+//!
+//! Two sources, by strength:
+//!
+//! - **Declared**: the client's own statement of its id-version binding,
+//!   via either the `cid` upgrade query param (binding the id to the
+//!   connection's `v` param) or a `relayVersion` field inside its awareness
+//!   state payload. Minted by the id's owner, so it stays correct no matter
+//!   who relays it. Overrides everything.
+//! - **Inferred**: the `v` query param of the connection that *introduced*
+//!   the id - the first live (non-null, solo) awareness entry the server has
+//!   ever seen for it. An echo can only echo what the server already
+//!   broadcast, so the first introduction is causally the owner's own
+//!   connection. Immutable once set (an id is one session on one build), and
+//!   rendered with a `~` prefix so its weaker provenance is visible.
+//!
+//! Nothing else may feed this. Binding transport facts to the ids embedded in
+//! *updates* stamped the deliverer's version onto the minter (one resync
+//! re-stamped ~4,300 ids), and non-first awareness entries can be echoes.
+//!
+//! Ephemeral by design: versions describe live clients, so a restart forgets
+//! them - at the cost that sessions which re-introduce their ids inside
+//! full-map relays after a restart stay unversioned until they declare.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::RwLock;
+
+pub const UNKNOWN: &str = "-";
+
+#[derive(Default)]
+struct _State {
+    declared: HashMap<u64, String>,
+    inferred: HashMap<u64, String>,
+    seen: HashSet<u64>,
+}
+
+pub struct Observation<'a> {
+    pub client_id: u64,
+    pub declared: Option<&'a str>,
+    pub solo_live: bool,
+    pub connection_version: Option<&'a str>,
+}
+
+pub struct Recorded {
+    pub version: String,
+    pub previous: Option<String>,
+}
+
+#[derive(Default)]
+pub struct ClientVersions {
+    state: RwLock<_State>,
+}
+
+impl ClientVersions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn _declare(state: &mut _State, client_id: u64, version: &str) -> Option<Recorded> {
+        let previous = state.declared.insert(client_id, version.to_string());
+        if previous.as_deref() == Some(version) {
+            return None;
+        }
+
+        Some(Recorded {
+            version: version.to_string(),
+            previous,
+        })
+    }
+
+    pub fn declare(&self, client_id: u64, version: &str) -> Option<Recorded> {
+        let mut state = self.state.write().unwrap();
+        state.seen.insert(client_id);
+        Self::_declare(&mut state, client_id, version)
+    }
+
+    pub fn observe(&self, observation: Observation) -> Option<Recorded> {
+        let mut state = self.state.write().unwrap();
+        let never_seen = state.seen.insert(observation.client_id);
+
+        if let Some(declared) = observation.declared {
+            return Self::_declare(&mut state, observation.client_id, declared);
+        }
+
+        if !(observation.solo_live && never_seen) {
+            return None;
+        }
+        let version = observation.connection_version?;
+
+        state
+            .inferred
+            .insert(observation.client_id, version.to_string());
+        Some(Recorded {
+            version: format!("~{version}"),
+            previous: None,
+        })
+    }
+
+    fn _lookup(state: &_State, client_id: u64) -> Option<String> {
+        if let Some(declared) = state.declared.get(&client_id) {
+            return Some(declared.clone());
+        }
+
+        state
+            .inferred
+            .get(&client_id)
+            .map(|version| format!("~{version}"))
+    }
+
+    pub fn describe(&self, client_ids: &[u64]) -> String {
+        let state = self.state.read().unwrap();
+        let mut versions: Vec<String> = client_ids
+            .iter()
+            .filter_map(|client_id| Self::_lookup(&state, *client_id))
+            .collect();
+        versions.sort_unstable();
+        versions.dedup();
+
+        if versions.is_empty() {
+            return UNKNOWN.to_string();
+        }
+
+        versions.join(",")
+    }
+
+    pub fn snapshot(&self) -> Vec<(u64, String)> {
+        let state = self.state.read().unwrap();
+        let mut entries: Vec<(u64, String)> = state
+            .declared
+            .keys()
+            .chain(state.inferred.keys())
+            .filter_map(|client_id| {
+                Self::_lookup(&state, *client_id).map(|version| (*client_id, version))
+            })
+            .collect();
+        entries.sort_unstable_by_key(|(client_id, _)| *client_id);
+        entries.dedup_by_key(|(client_id, _)| *client_id);
+        entries
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn declared(client_id: u64, version: &str) -> Observation<'_> {
+        Observation {
+            client_id,
+            declared: Some(version),
+            solo_live: true,
+            connection_version: None,
+        }
+    }
+
+    fn introduced(client_id: u64, connection_version: &str) -> Observation<'_> {
+        Observation {
+            client_id,
+            declared: None,
+            solo_live: true,
+            connection_version: Some(connection_version),
+        }
+    }
+
+    #[test]
+    fn a_declared_version_reports_bare() {
+        let versions = ClientVersions::new();
+        versions.observe(declared(1, "0.9.1"));
+
+        assert_eq!(versions.describe(&[1]), "0.9.1");
+    }
+
+    #[test]
+    fn a_first_introduction_infers_with_visible_provenance() {
+        let versions = ClientVersions::new();
+        versions.observe(introduced(1, "0.9.0"));
+
+        assert_eq!(versions.describe(&[1]), "~0.9.0");
+    }
+
+    #[test]
+    fn an_echo_after_introduction_cannot_rebind() {
+        let versions = ClientVersions::new();
+        versions.observe(introduced(1, "0.9.0"));
+        assert!(versions.observe(introduced(1, "0.8.8")).is_none());
+
+        assert_eq!(versions.describe(&[1]), "~0.9.0");
+    }
+
+    #[test]
+    fn an_id_first_seen_in_a_relay_is_never_inferable() {
+        let versions = ClientVersions::new();
+        versions.observe(Observation {
+            client_id: 1,
+            declared: None,
+            solo_live: false,
+            connection_version: Some("0.9.0"),
+        });
+        assert!(versions.observe(introduced(1, "0.9.0")).is_none());
+
+        assert_eq!(versions.describe(&[1]), UNKNOWN);
+    }
+
+    #[test]
+    fn a_declaration_overrides_an_inference() {
+        let versions = ClientVersions::new();
+        versions.observe(introduced(1, "0.9.0"));
+        versions.observe(declared(1, "0.9.1"));
+
+        assert_eq!(versions.describe(&[1]), "0.9.1");
+    }
+
+    #[test]
+    fn an_inference_never_overrides_a_declaration() {
+        let versions = ClientVersions::new();
+        versions.observe(declared(1, "0.9.1"));
+        versions.observe(introduced(1, "0.8.8"));
+
+        assert_eq!(versions.describe(&[1]), "0.9.1");
+    }
+
+    #[test]
+    fn a_connection_without_a_version_cannot_infer() {
+        let versions = ClientVersions::new();
+        assert!(versions
+            .observe(Observation {
+                client_id: 1,
+                declared: None,
+                solo_live: true,
+                connection_version: None,
+            })
+            .is_none());
+
+        assert_eq!(versions.describe(&[1]), UNKNOWN);
+    }
+
+    #[test]
+    fn repeated_declarations_log_once() {
+        let versions = ClientVersions::new();
+        assert!(versions.observe(declared(1, "0.9.1")).is_some());
+        assert!(versions.observe(declared(1, "0.9.1")).is_none());
+    }
+
+    #[test]
+    fn a_merged_update_across_builds_names_both() {
+        let versions = ClientVersions::new();
+        versions.observe(declared(1, "0.8.9"));
+        versions.observe(introduced(2, "0.9.0"));
+
+        assert_eq!(versions.describe(&[1, 2]), "0.8.9,~0.9.0");
+    }
+
+    #[test]
+    fn unrecorded_clients_do_not_mask_a_known_one() {
+        let versions = ClientVersions::new();
+        versions.observe(declared(1, "0.9.1"));
+
+        assert_eq!(versions.describe(&[1, 999]), "0.9.1");
+    }
+
+    #[test]
+    fn no_clients_at_all_reads_as_unknown() {
+        let versions = ClientVersions::new();
+
+        assert_eq!(versions.describe(&[]), UNKNOWN);
+    }
+
+    #[test]
+    fn a_pre_joined_declaration_reports_bare() {
+        let versions = ClientVersions::new();
+        versions.declare(1, "0.9.1");
+
+        assert_eq!(versions.describe(&[1]), "0.9.1");
+    }
+
+    #[test]
+    fn a_pre_joined_declaration_blocks_later_inference() {
+        let versions = ClientVersions::new();
+        versions.declare(1, "0.9.1");
+        assert!(versions.observe(introduced(1, "0.8.8")).is_none());
+
+        assert_eq!(versions.describe(&[1]), "0.9.1");
+    }
+
+    #[test]
+    fn a_matching_payload_declaration_after_a_pre_join_logs_nothing() {
+        let versions = ClientVersions::new();
+        assert!(versions.declare(1, "0.9.1").is_some());
+        assert!(versions.observe(declared(1, "0.9.1")).is_none());
+    }
+
+    #[test]
+    fn a_snapshot_lists_both_sources_in_id_order() {
+        let versions = ClientVersions::new();
+        versions.observe(introduced(20, "0.9.0"));
+        versions.observe(declared(10, "0.9.1"));
+
+        assert_eq!(
+            versions.snapshot(),
+            vec![(10, "0.9.1".to_string()), (20, "~0.9.0".to_string()),]
+        );
+    }
+}

--- a/crates/relay/src/client_versions.rs
+++ b/crates/relay/src/client_versions.rs
@@ -1,4 +1,4 @@
-//! Plugin version per Yjs client id, for annotating logs and gating access.
+//! Plugin version per Yjs client id, for annotating logs.
 //!
 //! Two sources, by strength:
 //!
@@ -25,22 +25,41 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::RwLock;
 
+/// Reported when no source has named a version for a client id: the client
+/// has not declared one and its introduction was not attributable.
 pub const UNKNOWN: &str = "-";
 
 #[derive(Default)]
 struct _State {
+    /// relayVersion payloads: owner-minted, overwritable (an upgraded client
+    /// re-declares under a new id, but a corrected payload should win).
     declared: HashMap<u64, String>,
+    /// First-introduction bindings: connection-inferred, immutable.
     inferred: HashMap<u64, String>,
+    /// Every id ever seen in any awareness entry, live or leave, solo or
+    /// relayed. An id already seen may be an echo, so it is never inferable.
     seen: HashSet<u64>,
+    /// `user.name` from awareness payloads (or the authenticated user on a
+    /// `cid` declaration). Payload content is owner-minted, so a name may be
+    /// taken from any delivery, relayed or not.
+    names: HashMap<u64, String>,
 }
 
 pub struct Observation<'a> {
     pub client_id: u64,
+    /// `relayVersion` from the entry's state payload, when present.
     pub declared: Option<&'a str>,
+    /// `user.name` from the entry's state payload, when present.
+    pub name: Option<&'a str>,
+    /// True only for a non-null entry that arrived alone: the shape of a
+    /// client broadcasting its own state, and the only shape eligible to
+    /// bind the connection's reported version.
     pub solo_live: bool,
+    /// The `v` query param of the connection this entry arrived on.
     pub connection_version: Option<&'a str>,
 }
 
+/// A recording that changed the table, so the caller can log the transition.
 pub struct Recorded {
     pub version: String,
     pub previous: Option<String>,
@@ -68,15 +87,26 @@ impl ClientVersions {
         })
     }
 
-    pub fn declare(&self, client_id: u64, version: &str) -> Option<Recorded> {
+    /// A client's own pre-joined binding: the `cid` upgrade param names the
+    /// id, the connection's `v` param supplies the version, and the
+    /// connection's authenticated user supplies the name. Same trust as an
+    /// awareness-payload declaration.
+    pub fn declare(&self, client_id: u64, version: &str, name: Option<&str>) -> Option<Recorded> {
         let mut state = self.state.write().unwrap();
         state.seen.insert(client_id);
+        if let Some(name) = name {
+            state.names.insert(client_id, name.to_string());
+        }
         Self::_declare(&mut state, client_id, version)
     }
 
+    /// Feed one awareness entry through the trust rules.
     pub fn observe(&self, observation: Observation) -> Option<Recorded> {
         let mut state = self.state.write().unwrap();
         let never_seen = state.seen.insert(observation.client_id);
+        if let Some(name) = observation.name {
+            state.names.insert(observation.client_id, name.to_string());
+        }
 
         if let Some(declared) = observation.declared {
             return Self::_declare(&mut state, observation.client_id, declared);
@@ -107,6 +137,11 @@ impl ClientVersions {
             .map(|version| format!("~{version}"))
     }
 
+    /// The version to print for the clients an update names.
+    ///
+    /// One version for the usual single-client edit; comma-separated when an
+    /// update merges several, so a mixed-build merge is visible rather than
+    /// silently reported as one build. `UNKNOWN` when none are recorded.
     pub fn describe(&self, client_ids: &[u64]) -> String {
         let state = self.state.read().unwrap();
         let mut versions: Vec<String> = client_ids
@@ -123,18 +158,21 @@ impl ClientVersions {
         versions.join(",")
     }
 
-    pub fn snapshot(&self) -> Vec<(u64, String)> {
+    /// Every known (client id, version, payload name), `~`-prefixed where
+    /// inferred, sorted by client id so successive reads diff cleanly.
+    pub fn snapshot(&self) -> Vec<(u64, String, Option<String>)> {
         let state = self.state.read().unwrap();
-        let mut entries: Vec<(u64, String)> = state
+        let mut entries: Vec<(u64, String, Option<String>)> = state
             .declared
             .keys()
             .chain(state.inferred.keys())
             .filter_map(|client_id| {
-                Self::_lookup(&state, *client_id).map(|version| (*client_id, version))
+                Self::_lookup(&state, *client_id)
+                    .map(|version| (*client_id, version, state.names.get(client_id).cloned()))
             })
             .collect();
-        entries.sort_unstable_by_key(|(client_id, _)| *client_id);
-        entries.dedup_by_key(|(client_id, _)| *client_id);
+        entries.sort_unstable_by_key(|(client_id, ..)| *client_id);
+        entries.dedup_by_key(|(client_id, ..)| *client_id);
         entries
     }
 }
@@ -147,6 +185,7 @@ mod tests {
         Observation {
             client_id,
             declared: Some(version),
+            name: None,
             solo_live: true,
             connection_version: None,
         }
@@ -156,6 +195,7 @@ mod tests {
         Observation {
             client_id,
             declared: None,
+            name: None,
             solo_live: true,
             connection_version: Some(connection_version),
         }
@@ -181,6 +221,7 @@ mod tests {
     fn an_echo_after_introduction_cannot_rebind() {
         let versions = ClientVersions::new();
         versions.observe(introduced(1, "0.9.0"));
+        // Another connection echoes the same id with its own version.
         assert!(versions.observe(introduced(1, "0.8.8")).is_none());
 
         assert_eq!(versions.describe(&[1]), "~0.9.0");
@@ -189,12 +230,15 @@ mod tests {
     #[test]
     fn an_id_first_seen_in_a_relay_is_never_inferable() {
         let versions = ClientVersions::new();
+        // Seen first in a full-map relay: not solo, so only marked seen.
         versions.observe(Observation {
             client_id: 1,
             declared: None,
+            name: None,
             solo_live: false,
             connection_version: Some("0.9.0"),
         });
+        // The later solo entry may be an echo of that relay - no binding.
         assert!(versions.observe(introduced(1, "0.9.0")).is_none());
 
         assert_eq!(versions.describe(&[1]), UNKNOWN);
@@ -225,6 +269,7 @@ mod tests {
             .observe(Observation {
                 client_id: 1,
                 declared: None,
+                name: None,
                 solo_live: true,
                 connection_version: None,
             })
@@ -267,7 +312,7 @@ mod tests {
     #[test]
     fn a_pre_joined_declaration_reports_bare() {
         let versions = ClientVersions::new();
-        versions.declare(1, "0.9.1");
+        versions.declare(1, "0.9.1", Some("Pat"));
 
         assert_eq!(versions.describe(&[1]), "0.9.1");
     }
@@ -275,7 +320,9 @@ mod tests {
     #[test]
     fn a_pre_joined_declaration_blocks_later_inference() {
         let versions = ClientVersions::new();
-        versions.declare(1, "0.9.1");
+        versions.declare(1, "0.9.1", Some("Pat"));
+        // The id is already seen and declared; an echoed introduction on
+        // some other connection changes nothing.
         assert!(versions.observe(introduced(1, "0.8.8")).is_none());
 
         assert_eq!(versions.describe(&[1]), "0.9.1");
@@ -284,7 +331,7 @@ mod tests {
     #[test]
     fn a_matching_payload_declaration_after_a_pre_join_logs_nothing() {
         let versions = ClientVersions::new();
-        assert!(versions.declare(1, "0.9.1").is_some());
+        assert!(versions.declare(1, "0.9.1", None).is_some());
         assert!(versions.observe(declared(1, "0.9.1")).is_none());
     }
 
@@ -296,7 +343,10 @@ mod tests {
 
         assert_eq!(
             versions.snapshot(),
-            vec![(10, "0.9.1".to_string()), (20, "~0.9.0".to_string()),]
+            vec![
+                (10, "0.9.1".to_string(), None),
+                (20, "~0.9.0".to_string(), None),
+            ]
         );
     }
 }

--- a/crates/relay/src/edit_author.rs
+++ b/crates/relay/src/edit_author.rs
@@ -1,0 +1,170 @@
+//! Identify the Yjs client ids behind an update.
+//!
+//! Two traps in reading those client ids, both of which fail by reporting no
+//! author rather than a wrong one:
+//!
+//! 1. Use `Update::state_vector_lower`, never `state_vector`. The latter is an
+//!    upper bound over blocks contiguous from clock 0, so it drops any client
+//!    whose first block in the update has a nonzero clock - which is every
+//!    update after a client's first.
+//! 2. Insertions and deletions live in different places. A deletion creates no
+//!    blocks, so a delete-only update has an empty state vector by any measure
+//!    and is attributable only through `delete_set`.
+
+use std::collections::HashSet;
+use yrs::updates::decoder::Decode;
+use yrs::Update;
+
+fn _clients_in(update: &Update) -> HashSet<u64> {
+    update
+        .state_vector_lower()
+        .iter()
+        .map(|(client_id, _)| client_id.get())
+        .chain(
+            update
+                .delete_set()
+                .iter()
+                .map(|(client_id, _)| client_id.get()),
+        )
+        .collect()
+}
+
+/// The yjs client ids an update came from, ascending.
+pub fn clients_in_update(update: &[u8]) -> Vec<u64> {
+    let Ok(decoded) = Update::decode_v1(update) else {
+        return Vec::new();
+    };
+
+    let mut ids: Vec<u64> = _clients_in(&decoded).into_iter().collect();
+    ids.sort_unstable();
+    ids
+}
+
+/// True when every client in the update is server-authored (53-bit yrs id,
+/// >= 2^32). PUD registration writes are the main case: the server mutates
+/// the doc's `users` map under its own client id, which fires
+/// `observe_update_v1` and would otherwise produce a webhook for internal
+/// bookkeeping that no human produced.
+pub fn is_server_only_update(update: &[u8]) -> bool {
+    let Ok(decoded) = Update::decode_v1(update) else {
+        return false;
+    };
+
+    let ids = _clients_in(&decoded);
+    !ids.is_empty() && ids.iter().all(|id| *id >= (1u64 << 32))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use yrs::{Map, ReadTxn, Text, Transact};
+
+    fn update_from(doc: &yrs::Doc, text: &str) -> Vec<u8> {
+        let body = doc.get_or_insert_text("body");
+        let before = doc.transact().state_vector();
+        {
+            let mut txn = doc.transact_mut();
+            body.push(&mut txn, text);
+        }
+        doc.transact().encode_state_as_update_v1(&before)
+    }
+
+    #[test]
+    fn clients_in_update_names_the_author() {
+        let a = yrs::Doc::new();
+        let update = update_from(&a, "hello");
+
+        assert_eq!(clients_in_update(&update), vec![a.client_id().get()]);
+        assert_eq!(clients_in_update(b"not an update"), Vec::<u64>::new());
+    }
+
+    #[test]
+    fn a_map_insert_still_names_its_client() {
+        let doc = yrs::Doc::new();
+        let map = doc.get_or_insert_map("filemeta_v0");
+        let before = doc.transact().state_vector();
+        {
+            let mut txn = doc.transact_mut();
+            map.insert(&mut txn, "notes/x.md", "guid-x");
+        }
+        let update = doc.transact().encode_state_as_update_v1(&before);
+
+        assert_eq!(clients_in_update(&update), vec![doc.client_id().get()]);
+    }
+
+    #[test]
+    fn a_map_removal_names_the_client_that_deleted() {
+        let doc = yrs::Doc::new();
+        let map = doc.get_or_insert_map("filemeta_v0");
+        {
+            let mut txn = doc.transact_mut();
+            map.insert(&mut txn, "notes/x.md", "guid-x");
+        }
+        let before = doc.transact().state_vector();
+        {
+            let mut txn = doc.transact_mut();
+            map.remove(&mut txn, "notes/x.md");
+        }
+        let update = doc.transact().encode_state_as_update_v1(&before);
+
+        assert_eq!(clients_in_update(&update), vec![doc.client_id().get()]);
+    }
+
+    #[test]
+    fn a_later_update_still_names_its_client() {
+        let doc = yrs::Doc::new();
+        let map = doc.get_or_insert_map("filemeta_v0");
+        {
+            let mut txn = doc.transact_mut();
+            map.insert(&mut txn, "notes/first.md", "guid-1");
+        }
+        let before = doc.transact().state_vector();
+        {
+            let mut txn = doc.transact_mut();
+            map.insert(&mut txn, "notes/second.md", "guid-2");
+        }
+        let update = doc.transact().encode_state_as_update_v1(&before);
+
+        assert!(
+            Update::decode_v1(&update)
+                .unwrap()
+                .state_vector()
+                .is_empty(),
+            "guards the reason for state_vector_lower"
+        );
+        assert_eq!(clients_in_update(&update), vec![doc.client_id().get()]);
+    }
+
+    #[test]
+    fn is_server_only_detects_53_bit_ids() {
+        let server_doc = yrs::Doc::with_client_id((1u64 << 32) + 42);
+        let update = update_from(&server_doc, "pud write");
+        assert!(is_server_only_update(&update));
+
+        let user_doc = yrs::Doc::with_client_id(42);
+        let user_update = update_from(&user_doc, "human edit");
+        assert!(!is_server_only_update(&user_update));
+    }
+
+    #[test]
+    fn mixed_server_and_user_ids_is_not_server_only() {
+        let user = yrs::Doc::with_client_id(42);
+        let server = yrs::Doc::with_client_id((1u64 << 32) + 1);
+        let from_user = update_from(&user, "user");
+        let from_server = update_from(&server, "server");
+
+        let merged = yrs::Doc::new();
+        {
+            let mut txn = merged.transact_mut();
+            txn.apply_update(Update::decode_v1(&from_user).unwrap())
+                .unwrap();
+            txn.apply_update(Update::decode_v1(&from_server).unwrap())
+                .unwrap();
+        }
+        let combined = merged
+            .transact()
+            .encode_state_as_update_v1(&yrs::StateVector::default());
+
+        assert!(!is_server_only_update(&combined));
+    }
+}

--- a/crates/relay/src/edit_author.rs
+++ b/crates/relay/src/edit_author.rs
@@ -1,63 +1,216 @@
-//! Identify the Yjs client ids behind an update.
+//! Identify who produced an update.
 //!
-//! Two traps in reading those client ids, both of which fail by reporting no
-//! author rather than a wrong one:
+//! The event callback's captured user describes whichever connection first
+//! loaded the doc, not the edit in hand, so it reads `-` forever on any doc
+//! first opened without a user token. The doc itself holds the truth:
+//! `register_new_client_ids` records client_id -> user in the PermanentUserData
+//! `users` map from each connection's authenticated identity, and an update
+//! names the clients it came from.
+//!
+//! Three traps in reading those client ids:
 //!
 //! 1. Use `Update::state_vector_lower`, never `state_vector`. The latter is an
 //!    upper bound over blocks contiguous from clock 0, so it drops any client
 //!    whose first block in the update has a nonzero clock - which is every
-//!    update after a client's first.
+//!    update after a client's first. It looks correct against a freshly-created
+//!    test doc and returns empty for most real traffic.
 //! 2. Insertions and deletions live in different places. A deletion creates no
-//!    blocks, so a delete-only update has an empty state vector by any measure
-//!    and is attributable only through `delete_set`.
+//!    blocks, so a delete-only update has an empty state vector by any measure;
+//!    its delete set is the only client information it carries.
+//! 3. Delete-set client ids name the owners of the *deleted* blocks - whoever
+//!    wrote what was removed - never the client doing the removing. A pure
+//!    deletion carries no authorship at all, so the deleting client is
+//!    unknowable from the update. Attributing the delete-set owner as the actor
+//!    misattributes every removal of someone else's entry: one person's 16-file
+//!    cleanup sweep was logged as three different users, each the entry's last
+//!    writer (observed 2026-08-14).
+//!
+//! Trap 3 is why actors and deleted-entry owners are separate lookups here:
+//! `user_for_update` names the actor and reports none for pure deletions,
+//! while `deleted_entries_user` names whose entries were removed.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use yrs::updates::decoder::Decode;
-use yrs::Update;
+use yrs::{Array, Map, Out, ReadTxn, Transact, Update};
 
-fn _clients_in(update: &Update) -> HashSet<u64> {
+/// Reverse the PUD "users" map (user -> {ids: [client_id]}) into client -> user.
+fn _user_by_client<T: ReadTxn>(txn: &T) -> HashMap<u64, String> {
+    let mut result = HashMap::new();
+    let Some(users_map) = txn.get_map("users") else {
+        return result;
+    };
+
+    for (user_id, user_val) in users_map.iter(txn) {
+        let Out::YMap(user_map) = user_val else {
+            continue;
+        };
+        let Some(Out::YArray(ids_arr)) = user_map.get(txn, "ids") else {
+            continue;
+        };
+        for item in ids_arr.iter(txn) {
+            let client_id = match item {
+                Out::Any(yrs::Any::Number(n)) => Some(n as u64),
+                Out::Any(yrs::Any::BigInt(n)) => Some(n as u64),
+                _ => None,
+            };
+            if let Some(cid) = client_id {
+                result.insert(cid, user_id.to_string());
+            }
+        }
+    }
+    result
+}
+
+/// Clients that wrote new blocks in `update`: the actors behind it.
+fn _insert_clients(update: &Update) -> HashSet<u64> {
     update
         .state_vector_lower()
         .iter()
         .map(|(client_id, _)| client_id.get())
-        .chain(
-            update
-                .delete_set()
-                .iter()
-                .map(|(client_id, _)| client_id.get()),
-        )
         .collect()
 }
 
-/// The yjs client ids an update came from, ascending.
+/// Owners of the blocks `update` deletes. NOT the deleting client (trap 3).
+fn _deleted_block_clients(update: &Update) -> HashSet<u64> {
+    update
+        .delete_set()
+        .iter()
+        .map(|(client_id, _)| client_id.get())
+        .collect()
+}
+
+/// The single user behind `clients`, or None.
+///
+/// None covers clients with no registered identity (server-authored updates,
+/// connections that predate their PUD registration) and multiple distinct
+/// users, which means a merged update that no single person authored - report
+/// none rather than picking one arbitrarily.
+fn _single_user<T: ReadTxn>(txn: &T, clients: &HashSet<u64>) -> Option<String> {
+    let by_client = _user_by_client(txn);
+
+    let users: HashSet<&String> = clients
+        .iter()
+        .filter_map(|client_id| by_client.get(client_id))
+        .collect();
+
+    match users.len() {
+        1 => users.into_iter().next().cloned(),
+        _ => None,
+    }
+}
+
+/// The user whose client authored `update`, resolved through the doc's PUD map.
+///
+/// Only new blocks name their author, so a pure deletion resolves to None:
+/// the update genuinely does not say who deleted (trap 3). A move (remove +
+/// insert in one transaction) still attributes, through its inserted block.
+pub fn user_for_update<T: ReadTxn>(txn: &T, update: &[u8]) -> Option<String> {
+    _single_user(txn, &_insert_clients(&Update::decode_v1(update).ok()?))
+}
+
+/// The user whose entries/content `update` deletes - the owner of what was
+/// removed, not the remover.
+pub fn deleted_entries_user<T: ReadTxn>(txn: &T, update: &[u8]) -> Option<String> {
+    _single_user(
+        txn,
+        &_deleted_block_clients(&Update::decode_v1(update).ok()?),
+    )
+}
+
+/// The yjs client ids that authored `update`'s new blocks, ascending.
 pub fn clients_in_update(update: &[u8]) -> Vec<u64> {
     let Ok(decoded) = Update::decode_v1(update) else {
         return Vec::new();
     };
 
-    let mut ids: Vec<u64> = _clients_in(&decoded).into_iter().collect();
+    let mut ids: Vec<u64> = _insert_clients(&decoded).into_iter().collect();
     ids.sort_unstable();
     ids
 }
 
-/// True when every client in the update is server-authored (53-bit yrs id,
-/// >= 2^32). PUD registration writes are the main case: the server mutates
-/// the doc's `users` map under its own client id, which fires
-/// `observe_update_v1` and would otherwise produce a webhook for internal
-/// bookkeeping that no human produced.
+/// True when every client named by the update - block authors and deleted-block
+/// owners alike - is server-authored (53-bit yrs id, >= 2^32). PUD registration
+/// writes are the main case: the server mutates the doc's `users` map under its
+/// own client id, which fires `observe_update_v1` and would otherwise produce a
+/// webhook for internal bookkeeping that no human produced.
 pub fn is_server_only_update(update: &[u8]) -> bool {
     let Ok(decoded) = Update::decode_v1(update) else {
         return false;
     };
 
-    let ids = _clients_in(&decoded);
+    let ids: HashSet<u64> = _insert_clients(&decoded)
+        .into_iter()
+        .chain(_deleted_block_clients(&decoded))
+        .collect();
     !ids.is_empty() && ids.iter().all(|id| *id >= (1u64 << 32))
+}
+
+/// `clients_in_update`, comma-separated, or "-" when the update names none.
+pub fn clients_for_update(update: &[u8]) -> String {
+    _render_clients(clients_in_update(update))
+}
+
+/// The owners of `update`'s deleted blocks, comma-separated, or "-" when it
+/// deletes nothing. Also the honest signal that an actorless update was a
+/// deletion rather than server bookkeeping.
+pub fn deleted_clients_for_update(update: &[u8]) -> String {
+    let Ok(decoded) = Update::decode_v1(update) else {
+        return "-".to_string();
+    };
+
+    let mut ids: Vec<u64> = _deleted_block_clients(&decoded).into_iter().collect();
+    ids.sort_unstable();
+    _render_clients(ids)
+}
+
+fn _render_clients(ids: Vec<u64>) -> String {
+    if ids.is_empty() {
+        return "-".to_string();
+    }
+
+    ids.iter().map(u64::to_string).collect::<Vec<_>>().join(",")
+}
+
+/// Same lookup, reading the PUD map out of the post-update snapshot the event
+/// carries. Update callbacks fire while the edited doc's awareness lock is held
+/// as a writer, so the live doc is not readable from there.
+pub fn user_from_snapshot(snapshot: &[u8], update: &[u8]) -> Option<String> {
+    let doc = _doc_from(snapshot)?;
+    let txn = doc.transact();
+    user_for_update(&txn, update)
+}
+
+/// `deleted_entries_user`, resolved from the event's snapshot like
+/// `user_from_snapshot`.
+pub fn deleted_user_from_snapshot(snapshot: &[u8], update: &[u8]) -> Option<String> {
+    let doc = _doc_from(snapshot)?;
+    let txn = doc.transact();
+    deleted_entries_user(&txn, update)
+}
+
+fn _doc_from(snapshot: &[u8]) -> Option<yrs::Doc> {
+    let doc = yrs::Doc::new();
+    {
+        let mut txn = doc.transact_mut();
+        txn.apply_update(Update::decode_v1(snapshot).ok()?).ok()?;
+    }
+    Some(doc)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use yrs::{Map, ReadTxn, Text, Transact};
+    use yrs::{Map, Text, Transact};
+
+    fn register(doc: &yrs::Doc, user_id: &str, client_ids: &[u64]) {
+        let users = doc.get_or_insert_map("users");
+        let mut txn = doc.transact_mut();
+        let entry = users.insert(&mut txn, user_id, yrs::MapPrelim::default());
+        let ids = entry.insert(&mut txn, "ids", yrs::ArrayPrelim::default());
+        for cid in client_ids {
+            ids.push_back(&mut txn, *cid as f64);
+        }
+    }
 
     fn update_from(doc: &yrs::Doc, text: &str) -> Vec<u8> {
         let body = doc.get_or_insert_text("body");
@@ -67,6 +220,73 @@ mod tests {
             body.push(&mut txn, text);
         }
         doc.transact().encode_state_as_update_v1(&before)
+    }
+
+    /// A second doc holding the same state as `a`, with its own client id.
+    fn peer_of(a: &yrs::Doc) -> yrs::Doc {
+        let full = a
+            .transact()
+            .encode_state_as_update_v1(&yrs::StateVector::default());
+        let b = yrs::Doc::with_client_id(a.client_id().get() + 100);
+        {
+            let mut txn = b.transact_mut();
+            txn.apply_update(Update::decode_v1(&full).unwrap()).unwrap();
+        }
+        b
+    }
+
+    #[test]
+    fn resolves_the_user_whose_client_authored_the_update() {
+        let doc = yrs::Doc::new();
+        let update = update_from(&doc, "hello");
+        register(&doc, "user-a", &[doc.client_id().get()]);
+
+        assert_eq!(
+            user_for_update(&doc.transact(), &update),
+            Some("user-a".to_string())
+        );
+    }
+
+    #[test]
+    fn an_unregistered_client_resolves_to_none() {
+        let doc = yrs::Doc::new();
+        let update = update_from(&doc, "hello");
+        register(&doc, "user-a", &[doc.client_id().get() + 1]);
+
+        assert_eq!(user_for_update(&doc.transact(), &update), None);
+    }
+
+    #[test]
+    fn a_doc_with_no_users_map_resolves_to_none() {
+        let doc = yrs::Doc::new();
+        let update = update_from(&doc, "hello");
+
+        assert_eq!(user_for_update(&doc.transact(), &update), None);
+    }
+
+    #[test]
+    fn an_update_merging_two_authors_reports_neither() {
+        let a = yrs::Doc::new();
+        let b = yrs::Doc::with_client_id(a.client_id().get() + 100);
+        let from_a = update_from(&a, "aaa");
+        let from_b = update_from(&b, "bbb");
+
+        let merged = yrs::Doc::new();
+        {
+            let mut txn = merged.transact_mut();
+            txn.apply_update(Update::decode_v1(&from_a).unwrap())
+                .unwrap();
+            txn.apply_update(Update::decode_v1(&from_b).unwrap())
+                .unwrap();
+        }
+        let combined = merged
+            .transact()
+            .encode_state_as_update_v1(&yrs::StateVector::default());
+
+        register(&merged, "user-a", &[a.client_id().get()]);
+        register(&merged, "user-b", &[b.client_id().get()]);
+
+        assert_eq!(user_for_update(&merged.transact(), &combined), None);
     }
 
     #[test]
@@ -92,8 +312,12 @@ mod tests {
         assert_eq!(clients_in_update(&update), vec![doc.client_id().get()]);
     }
 
+    /// A membership removal has no actor: deleting creates no blocks, and the
+    /// delete set names the entry's author. Even when deleter == author, the
+    /// update cannot say so, and reporting the author as actor is what logged
+    /// one person's cleanup sweep as three other users (2026-08-14).
     #[test]
-    fn a_map_removal_names_the_client_that_deleted() {
+    fn a_removal_has_no_actor_and_names_the_entry_author_as_deleted() {
         let doc = yrs::Doc::new();
         let map = doc.get_or_insert_map("filemeta_v0");
         {
@@ -106,8 +330,88 @@ mod tests {
             map.remove(&mut txn, "notes/x.md");
         }
         let update = doc.transact().encode_state_as_update_v1(&before);
+        register(&doc, "user-a", &[doc.client_id().get()]);
 
-        assert_eq!(clients_in_update(&update), vec![doc.client_id().get()]);
+        assert_eq!(clients_in_update(&update), Vec::<u64>::new());
+        assert_eq!(user_for_update(&doc.transact(), &update), None);
+        assert_eq!(
+            deleted_clients_for_update(&update),
+            doc.client_id().get().to_string()
+        );
+        assert_eq!(
+            deleted_entries_user(&doc.transact(), &update),
+            Some("user-a".to_string())
+        );
+    }
+
+    /// The production shape behind this module's trap 3: B sweeps an entry A
+    /// created (a zombie cleanup). The update's only client id is A's, so an
+    /// actor reading of the delete set would blame A for B's deletion.
+    #[test]
+    fn removing_anothers_entry_names_them_as_deleted_user_not_actor() {
+        let a = yrs::Doc::new();
+        let map_a = a.get_or_insert_map("filemeta_v0");
+        {
+            let mut txn = a.transact_mut();
+            map_a.insert(&mut txn, "notes/zombie.md", "guid-z");
+        }
+        let b = peer_of(&a);
+
+        let map_b = b.get_or_insert_map("filemeta_v0");
+        let before = b.transact().state_vector();
+        {
+            let mut txn = b.transact_mut();
+            map_b.remove(&mut txn, "notes/zombie.md");
+        }
+        let update = b.transact().encode_state_as_update_v1(&before);
+        register(&b, "user-a", &[a.client_id().get()]);
+        register(&b, "user-b", &[b.client_id().get()]);
+
+        assert_eq!(user_for_update(&b.transact(), &update), None);
+        assert_eq!(
+            deleted_entries_user(&b.transact(), &update),
+            Some("user-a".to_string()),
+            "the delete set names the entry's author, which is exactly why it \
+             must not be reported as the deleter"
+        );
+        assert_eq!(
+            deleted_clients_for_update(&update),
+            a.client_id().get().to_string()
+        );
+    }
+
+    /// A move is remove + insert in one transaction. The inserted block names
+    /// the mover, so moving someone else's entry attributes correctly - it must
+    /// not be swallowed by the two-users-means-none guard.
+    #[test]
+    fn moving_anothers_entry_attributes_the_mover() {
+        let a = yrs::Doc::new();
+        let map_a = a.get_or_insert_map("filemeta_v0");
+        {
+            let mut txn = a.transact_mut();
+            map_a.insert(&mut txn, "notes/old.md", "guid-m");
+        }
+        let b = peer_of(&a);
+
+        let map_b = b.get_or_insert_map("filemeta_v0");
+        let before = b.transact().state_vector();
+        {
+            let mut txn = b.transact_mut();
+            map_b.remove(&mut txn, "notes/old.md");
+            map_b.insert(&mut txn, "notes/new.md", "guid-m");
+        }
+        let update = b.transact().encode_state_as_update_v1(&before);
+        register(&b, "user-a", &[a.client_id().get()]);
+        register(&b, "user-b", &[b.client_id().get()]);
+
+        assert_eq!(
+            user_for_update(&b.transact(), &update),
+            Some("user-b".to_string())
+        );
+        assert_eq!(
+            deleted_entries_user(&b.transact(), &update),
+            Some("user-a".to_string())
+        );
     }
 
     #[test]
@@ -133,6 +437,12 @@ mod tests {
             "guards the reason for state_vector_lower"
         );
         assert_eq!(clients_in_update(&update), vec![doc.client_id().get()]);
+
+        register(&doc, "user-a", &[doc.client_id().get()]);
+        assert_eq!(
+            user_for_update(&doc.transact(), &update),
+            Some("user-a".to_string())
+        );
     }
 
     #[test]
@@ -144,6 +454,35 @@ mod tests {
         let user_doc = yrs::Doc::with_client_id(42);
         let user_update = update_from(&user_doc, "human edit");
         assert!(!is_server_only_update(&user_update));
+    }
+
+    /// A server-side deletion of a user's blocks still involves that user's
+    /// ids through the delete set, so it must not be suppressed as server-only.
+    #[test]
+    fn a_server_deletion_of_user_content_is_not_server_only() {
+        let user = yrs::Doc::with_client_id(42);
+        let map_u = user.get_or_insert_map("filemeta_v0");
+        {
+            let mut txn = user.transact_mut();
+            map_u.insert(&mut txn, "notes/x.md", "guid-x");
+        }
+        let full = user
+            .transact()
+            .encode_state_as_update_v1(&yrs::StateVector::default());
+        let server = yrs::Doc::with_client_id((1u64 << 32) + 1);
+        {
+            let mut txn = server.transact_mut();
+            txn.apply_update(Update::decode_v1(&full).unwrap()).unwrap();
+        }
+        let map_s = server.get_or_insert_map("filemeta_v0");
+        let before = server.transact().state_vector();
+        {
+            let mut txn = server.transact_mut();
+            map_s.remove(&mut txn, "notes/x.md");
+        }
+        let update = server.transact().encode_state_as_update_v1(&before);
+
+        assert!(!is_server_only_update(&update));
     }
 
     #[test]
@@ -166,5 +505,14 @@ mod tests {
             .encode_state_as_update_v1(&yrs::StateVector::default());
 
         assert!(!is_server_only_update(&combined));
+    }
+
+    #[test]
+    fn clients_for_update_formats_as_comma_separated() {
+        let a = yrs::Doc::new();
+        let update = update_from(&a, "hello");
+
+        assert_eq!(clients_for_update(&update), a.client_id().get().to_string());
+        assert_eq!(clients_for_update(b"not an update"), "-");
     }
 }

--- a/crates/relay/src/edit_bursts.rs
+++ b/crates/relay/src/edit_bursts.rs
@@ -1,0 +1,525 @@
+//! Collapses a run of edits to one doc by one user into a single logged burst.
+//!
+//! A keystroke is one Yjs update, so typing a sentence produces dozens of
+//! `Doc edited` lines that differ only in timestamp. The interesting unit for
+//! an operator is the burst: who touched what, for how long, and how much
+//! changed.
+//!
+//! The first edit of a burst logs immediately - a debounce that only reported
+//! on quiesce would hide active editing for the whole window, which is the one
+//! moment someone tailing the log wants to see. Everything after it accrues
+//! here until the burst goes quiet, and the sweeper emits the totals.
+//!
+//! Bursts are keyed by doc *and* user: two people in one file are two bursts,
+//! so neither line attributes the other's typing.
+
+use std::collections::{BTreeSet, HashMap};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+/// Quiet period after which a burst is considered finished. Chosen against real
+/// traffic: continuous typing lands updates ~0.15s apart, while pauses to think
+/// reach 9s, so a shorter window splits one editing session into several lines.
+pub const BURST_QUIET: Duration = Duration::from_secs(10);
+
+/// Identifies a burst. The doc id rather than the vpath: a rename mid-burst
+/// would otherwise split it in two, and the vpath is only a display concern.
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct _BurstKey {
+    doc_id: String,
+    user: String,
+}
+
+struct _Burst {
+    /// Display fields, refreshed on every edit so the flushed line reports the
+    /// vpath the doc had when editing stopped.
+    vpath: String,
+    /// The shared folder the doc belongs to; a doc id alone does not say which.
+    channel: String,
+    /// Every Yjs client id seen in the burst, so the summary can name the
+    /// build(s) that produced it. A burst is one user, but a user may edit from
+    /// more than one device.
+    clients: BTreeSet<u64>,
+    /// Edits after the leading one, which is logged rather than accrued.
+    suppressed: u64,
+    /// Bytes across the whole burst, leading edit included.
+    bytes: usize,
+    started: Instant,
+    last_edit: Instant,
+}
+
+/// A burst that has gone quiet and is ready to log.
+pub struct FinishedBurst {
+    pub doc_id: String,
+    pub user: String,
+    pub vpath: String,
+    pub channel: String,
+    pub clients: Vec<u64>,
+    /// Total edits in the burst, including the one already logged.
+    pub edits: u64,
+    pub bytes: usize,
+    pub span: Duration,
+}
+
+/// Whether an edit should be logged now or folded into a pending burst.
+pub enum Verdict {
+    /// First edit for this doc+user; log it as it arrives.
+    Leading,
+    /// Burst already announced; the totals will come from the flush.
+    Suppressed,
+}
+
+/// One recorded edit. A struct rather than positional arguments because four
+/// of these fields are strings that would silently transpose.
+pub struct Edit<'a> {
+    pub doc_id: &'a str,
+    pub user: &'a str,
+    /// Stored for the eventual flush, so passing the resolved path (not "-")
+    /// whenever it is known keeps the summary line useful.
+    pub vpath: &'a str,
+    pub channel: &'a str,
+    pub clients: &'a [u64],
+    pub bytes: usize,
+}
+
+#[derive(Default)]
+pub struct EditBursts {
+    bursts: Mutex<HashMap<_BurstKey, _Burst>>,
+}
+
+impl EditBursts {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Records an edit, reporting whether the caller should log it.
+    pub fn record(&self, edit: Edit) -> Verdict {
+        self.record_at(edit, Instant::now())
+    }
+
+    /// `now` is a parameter so a caller can replay a recorded cadence against
+    /// the same clock the sweep reads; reading it internally would leave the
+    /// two disagreeing and flush bursts mid-run.
+    fn record_at(&self, edit: Edit, now: Instant) -> Verdict {
+        let Edit {
+            doc_id,
+            user,
+            vpath,
+            channel,
+            clients,
+            bytes,
+        } = edit;
+        let mut bursts = self.bursts.lock().unwrap();
+        let key = _BurstKey {
+            doc_id: doc_id.to_string(),
+            user: user.to_string(),
+        };
+        match bursts.get_mut(&key) {
+            Some(burst) => {
+                burst.suppressed += 1;
+                burst.bytes += bytes;
+                burst.last_edit = now;
+                burst.clients.extend(clients);
+                if !vpath.is_empty() && vpath != "-" {
+                    burst.vpath = vpath.to_string();
+                }
+                Verdict::Suppressed
+            }
+            None => {
+                bursts.insert(
+                    key,
+                    _Burst {
+                        vpath: vpath.to_string(),
+                        channel: channel.to_string(),
+                        clients: clients.iter().copied().collect(),
+                        suppressed: 0,
+                        bytes,
+                        started: now,
+                        last_edit: now,
+                    },
+                );
+                Verdict::Leading
+            }
+        }
+    }
+
+    /// Removes and returns every burst quiet for at least `BURST_QUIET`.
+    ///
+    /// Bursts whose only edit was the leading one are dropped without being
+    /// returned: that line already said everything, and a summary repeating it
+    /// with `edits=1` would double the output this exists to reduce.
+    pub fn take_finished(&self) -> Vec<FinishedBurst> {
+        self.take_finished_as_of(Instant::now())
+    }
+
+    fn take_finished_as_of(&self, now: Instant) -> Vec<FinishedBurst> {
+        let mut bursts = self.bursts.lock().unwrap();
+        let quiet: Vec<_BurstKey> = bursts
+            .iter()
+            .filter(|(_, burst)| now.saturating_duration_since(burst.last_edit) >= BURST_QUIET)
+            .map(|(key, _)| key.clone())
+            .collect();
+
+        quiet
+            .into_iter()
+            .filter_map(|key| {
+                let burst = bursts.remove(&key)?;
+                if burst.suppressed == 0 {
+                    return None;
+                }
+
+                Some(FinishedBurst {
+                    doc_id: key.doc_id,
+                    user: key.user,
+                    vpath: burst.vpath,
+                    channel: burst.channel,
+                    clients: burst.clients.into_iter().collect(),
+                    edits: burst.suppressed + 1,
+                    bytes: burst.bytes,
+                    span: burst.last_edit.saturating_duration_since(burst.started),
+                })
+            })
+            .collect()
+    }
+
+    /// Every pending burst, ignoring the quiet window, for shutdown.
+    ///
+    /// Without this a burst in flight when the server stops is never reported,
+    /// which loses exactly the edits made just before a restart.
+    pub fn drain_all(&self) -> Vec<FinishedBurst> {
+        let mut bursts = self.bursts.lock().unwrap();
+        bursts
+            .drain()
+            .filter(|(_, burst)| burst.suppressed > 0)
+            .map(|(key, burst)| FinishedBurst {
+                doc_id: key.doc_id,
+                user: key.user,
+                vpath: burst.vpath,
+                channel: burst.channel,
+                clients: burst.clients.into_iter().collect(),
+                edits: burst.suppressed + 1,
+                bytes: burst.bytes,
+                span: burst.last_edit.saturating_duration_since(burst.started),
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn is_leading(verdict: Verdict) -> bool {
+        matches!(verdict, Verdict::Leading)
+    }
+
+    #[test]
+    fn the_first_edit_logs_and_the_rest_do_not() {
+        let bursts = EditBursts::new();
+        assert!(is_leading(bursts.record(Edit {
+            doc_id: "doc",
+            user: "alan",
+            vpath: "/a.md",
+            channel: "folder",
+            clients: &[1],
+            bytes: 26,
+        })));
+        assert!(!is_leading(bursts.record(Edit {
+            doc_id: "doc",
+            user: "alan",
+            vpath: "/a.md",
+            channel: "folder",
+            clients: &[1],
+            bytes: 26,
+        })));
+        assert!(!is_leading(bursts.record(Edit {
+            doc_id: "doc",
+            user: "alan",
+            vpath: "/a.md",
+            channel: "folder",
+            clients: &[1],
+            bytes: 26,
+        })));
+    }
+
+    #[test]
+    fn a_quiet_burst_reports_totals_including_the_leading_edit() {
+        let bursts = EditBursts::new();
+        bursts.record(Edit {
+            doc_id: "doc",
+            user: "alan",
+            vpath: "/a.md",
+            channel: "folder",
+            clients: &[1],
+            bytes: 26,
+        });
+        bursts.record(Edit {
+            doc_id: "doc",
+            user: "alan",
+            vpath: "/a.md",
+            channel: "folder",
+            clients: &[1],
+            bytes: 11,
+        });
+        bursts.record(Edit {
+            doc_id: "doc",
+            user: "alan",
+            vpath: "/a.md",
+            channel: "folder",
+            clients: &[1],
+            bytes: 3,
+        });
+
+        let finished = bursts.take_finished_as_of(Instant::now() + BURST_QUIET);
+        assert_eq!(finished.len(), 1);
+        assert_eq!(finished[0].edits, 3);
+        assert_eq!(finished[0].bytes, 40);
+        assert_eq!(finished[0].vpath, "/a.md");
+    }
+
+    #[test]
+    fn a_burst_still_being_typed_is_not_flushed() {
+        let bursts = EditBursts::new();
+        bursts.record(Edit {
+            doc_id: "doc",
+            user: "alan",
+            vpath: "/a.md",
+            channel: "folder",
+            clients: &[1],
+            bytes: 26,
+        });
+        bursts.record(Edit {
+            doc_id: "doc",
+            user: "alan",
+            vpath: "/a.md",
+            channel: "folder",
+            clients: &[1],
+            bytes: 26,
+        });
+
+        assert!(bursts.take_finished().is_empty());
+    }
+
+    #[test]
+    fn a_lone_edit_is_dropped_rather_than_summarized() {
+        let bursts = EditBursts::new();
+        bursts.record(Edit {
+            doc_id: "doc",
+            user: "alan",
+            vpath: "/a.md",
+            channel: "folder",
+            clients: &[1],
+            bytes: 26,
+        });
+
+        assert!(bursts
+            .take_finished_as_of(Instant::now() + BURST_QUIET)
+            .is_empty());
+    }
+
+    #[test]
+    fn two_users_in_one_doc_are_separate_bursts() {
+        let bursts = EditBursts::new();
+        assert!(is_leading(bursts.record(Edit {
+            doc_id: "doc",
+            user: "alan",
+            vpath: "/a.md",
+            channel: "folder",
+            clients: &[1],
+            bytes: 26,
+        })));
+        assert!(is_leading(bursts.record(Edit {
+            doc_id: "doc",
+            user: "heather",
+            vpath: "/a.md",
+            channel: "folder",
+            clients: &[1],
+            bytes: 26,
+        })));
+        bursts.record(Edit {
+            doc_id: "doc",
+            user: "alan",
+            vpath: "/a.md",
+            channel: "folder",
+            clients: &[1],
+            bytes: 26,
+        });
+        bursts.record(Edit {
+            doc_id: "doc",
+            user: "heather",
+            vpath: "/a.md",
+            channel: "folder",
+            clients: &[1],
+            bytes: 26,
+        });
+
+        let mut finished = bursts.take_finished_as_of(Instant::now() + BURST_QUIET);
+        finished.sort_by(|a, b| a.user.cmp(&b.user));
+        assert_eq!(finished.len(), 2);
+        assert_eq!(finished[0].user, "alan");
+        assert_eq!(finished[1].user, "heather");
+    }
+
+    #[test]
+    fn a_later_edit_starts_a_new_burst_that_logs_again() {
+        let bursts = EditBursts::new();
+        bursts.record(Edit {
+            doc_id: "doc",
+            user: "alan",
+            vpath: "/a.md",
+            channel: "folder",
+            clients: &[1],
+            bytes: 26,
+        });
+        bursts.record(Edit {
+            doc_id: "doc",
+            user: "alan",
+            vpath: "/a.md",
+            channel: "folder",
+            clients: &[1],
+            bytes: 26,
+        });
+        assert_eq!(
+            bursts
+                .take_finished_as_of(Instant::now() + BURST_QUIET)
+                .len(),
+            1
+        );
+
+        assert!(is_leading(bursts.record(Edit {
+            doc_id: "doc",
+            user: "alan",
+            vpath: "/a.md",
+            channel: "folder",
+            clients: &[1],
+            bytes: 26,
+        })));
+    }
+
+    #[test]
+    fn a_rename_mid_burst_reports_the_latest_vpath() {
+        let bursts = EditBursts::new();
+        bursts.record(Edit {
+            doc_id: "doc",
+            user: "alan",
+            vpath: "/before.md",
+            channel: "folder",
+            clients: &[1],
+            bytes: 26,
+        });
+        bursts.record(Edit {
+            doc_id: "doc",
+            user: "alan",
+            vpath: "/after.md",
+            channel: "folder",
+            clients: &[1],
+            bytes: 26,
+        });
+
+        let finished = bursts.take_finished_as_of(Instant::now() + BURST_QUIET);
+        assert_eq!(finished[0].vpath, "/after.md");
+    }
+
+    #[test]
+    fn an_unresolved_vpath_does_not_overwrite_a_known_one() {
+        let bursts = EditBursts::new();
+        bursts.record(Edit {
+            doc_id: "doc",
+            user: "alan",
+            vpath: "/a.md",
+            channel: "folder",
+            clients: &[1],
+            bytes: 26,
+        });
+        bursts.record(Edit {
+            doc_id: "doc",
+            user: "alan",
+            vpath: "-",
+            channel: "folder",
+            clients: &[1],
+            bytes: 26,
+        });
+
+        let finished = bursts.take_finished_as_of(Instant::now() + BURST_QUIET);
+        assert_eq!(finished[0].vpath, "/a.md");
+    }
+
+    #[test]
+    fn replaying_the_observed_keystroke_cadence_yields_one_burst() {
+        // Real gaps from a 69-edit / 26.2s typing run: continuous typing at
+        // ~0.15s with pauses up to 9.34s, all inside one quiet window.
+        let gaps_ms: [u64; 68] = [
+            1400, 104, 42, 315, 199, 137, 160, 142, 1299, 174, 36, 201, 121, 132, 95, 512, 76, 100,
+            121, 103, 80, 56, 76, 1309, 9335, 384, 216, 159, 80, 105, 138, 98, 135, 136, 96, 105,
+            155, 112, 76, 123, 185, 125, 1875, 124, 96, 60, 232, 144, 399, 209, 120, 121, 157, 138,
+            92, 99, 158, 67, 172, 128, 136, 116, 116, 184, 163, 336, 553, 1420,
+        ];
+
+        let bursts = EditBursts::new();
+        let mut at = Instant::now();
+        let mut leading = 0;
+        if is_leading(bursts.record_at(
+            Edit {
+                doc_id: "doc",
+                user: "alan",
+                vpath: "/a.md",
+                channel: "folder",
+                clients: &[1],
+                bytes: 26,
+            },
+            at,
+        )) {
+            leading += 1;
+        }
+        for gap in gaps_ms {
+            at += Duration::from_millis(gap);
+            // A sweep runs between edits; none should fire mid-burst.
+            assert!(bursts.take_finished_as_of(at).is_empty());
+            if is_leading(bursts.record_at(
+                Edit {
+                    doc_id: "doc",
+                    user: "alan",
+                    vpath: "/a.md",
+                    channel: "folder",
+                    clients: &[1],
+                    bytes: 26,
+                },
+                at,
+            )) {
+                leading += 1;
+            }
+        }
+
+        let finished = bursts.take_finished_as_of(at + BURST_QUIET);
+        assert_eq!(leading, 1, "only the first edit should log immediately");
+        assert_eq!(finished.len(), 1, "the run should collapse to one burst");
+        assert_eq!(finished[0].edits, 69);
+    }
+
+    #[test]
+    fn shutdown_drains_bursts_that_have_not_gone_quiet() {
+        let bursts = EditBursts::new();
+        bursts.record(Edit {
+            doc_id: "doc",
+            user: "alan",
+            vpath: "/a.md",
+            channel: "folder",
+            clients: &[1],
+            bytes: 26,
+        });
+        bursts.record(Edit {
+            doc_id: "doc",
+            user: "alan",
+            vpath: "/a.md",
+            channel: "folder",
+            clients: &[1],
+            bytes: 14,
+        });
+
+        let drained = bursts.drain_all();
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].edits, 2);
+        assert_eq!(drained[0].bytes, 40);
+        assert!(bursts.take_finished().is_empty());
+    }
+}

--- a/crates/relay/src/lib.rs
+++ b/crates/relay/src/lib.rs
@@ -8,10 +8,12 @@ pub mod doc_lifecycle;
 pub mod doc_restore;
 pub mod doc_versions;
 pub mod edit_author;
+pub mod edit_bursts;
 pub mod migrations;
 pub mod server;
 pub mod stores;
 pub mod subdocs;
 #[cfg(test)]
 pub(crate) mod test_util;
+pub mod vpath_index;
 pub mod webhook;

--- a/crates/relay/src/lib.rs
+++ b/crates/relay/src/lib.rs
@@ -1,11 +1,13 @@
 #![doc = include_str!("../README.md")]
 
 pub mod cli;
+pub mod client_versions;
 pub mod convert;
 pub mod doc_inspect;
 pub mod doc_lifecycle;
 pub mod doc_restore;
 pub mod doc_versions;
+pub mod edit_author;
 pub mod migrations;
 pub mod server;
 pub mod stores;

--- a/crates/relay/src/main.rs
+++ b/crates/relay/src/main.rs
@@ -929,7 +929,15 @@ async fn main() -> Result<()> {
                 webhook_configs,
             )
             .await?
-            .with_allowed_client_versions(config.server.allowed_client_versions);
+            .with_allowed_client_versions(config.server.allowed_client_versions)
+            .with_semantic_logging(config.server.semantic_logging)
+            .with_user_names(
+                config
+                    .server
+                    .user_names
+                    .iter()
+                    .map(|(id, name)| (id.clone(), name.clone())),
+            );
 
             let redact_errors = config.server.redact_errors;
             let server = Arc::new(server);

--- a/crates/relay/src/main.rs
+++ b/crates/relay/src/main.rs
@@ -928,7 +928,8 @@ async fn main() -> Result<()> {
                 config.server.doc_gc,
                 webhook_configs,
             )
-            .await?;
+            .await?
+            .with_allowed_client_versions(config.server.allowed_client_versions);
 
             let redact_errors = config.server.redact_errors;
             let server = Arc::new(server);

--- a/crates/relay/src/server.rs
+++ b/crates/relay/src/server.rs
@@ -1,6 +1,8 @@
 use crate::client_versions::{self, ClientVersions};
 use crate::doc_lifecycle::{AttachGuard, AttachKind, DocRegistry, LifecycleConfig};
 use crate::edit_author;
+use crate::edit_bursts::{self, EditBursts, Verdict};
+use crate::vpath_index::VPathIndex;
 use anyhow::{anyhow, Result};
 use axum::{
     body::Bytes,
@@ -250,6 +252,10 @@ pub struct Server {
     allowed_client_versions: HashSet<String>,
     denial_log_throttle: Mutex<HashMap<String, DenialLogState>>,
     client_versions: Arc<ClientVersions>,
+    vpath_index: Arc<VPathIndex>,
+    user_names: Arc<HashMap<String, String>>,
+    edit_bursts: Arc<EditBursts>,
+    semantic_logging: bool,
 }
 
 type ClientVersionRecorder =
@@ -331,6 +337,10 @@ impl Server {
             allowed_client_versions: HashSet::new(),
             denial_log_throttle: Mutex::new(HashMap::new()),
             client_versions: Arc::new(ClientVersions::new()),
+            vpath_index: Arc::new(VPathIndex::default()),
+            user_names: Arc::new(HashMap::new()),
+            edit_bursts: Arc::new(EditBursts::new()),
+            semantic_logging: false,
         })
     }
 
@@ -344,6 +354,23 @@ impl Server {
                 "Requiring client version in {:?} for doc websocket access",
                 self.allowed_client_versions
             );
+        }
+        self
+    }
+
+    pub fn with_user_names(mut self, names: impl IntoIterator<Item = (String, String)>) -> Self {
+        let names: HashMap<String, String> = names.into_iter().collect();
+        if !names.is_empty() {
+            tracing::info!("Loaded display names for {} user id(s)", names.len());
+        }
+        self.user_names = Arc::new(names);
+        self
+    }
+
+    pub fn with_semantic_logging(mut self, enabled: bool) -> Self {
+        self.semantic_logging = enabled;
+        if enabled {
+            tracing::info!("Semantic logging enabled: edit attribution, vpath resolution, and /client-versions endpoint are active");
         }
         self
     }
@@ -391,6 +418,11 @@ impl Server {
             _ => {
                 if let Some(suppressed) = self.denial_log_permit(user) {
                     tracing::warn!(
+                        name = %self
+                            .user_names
+                            .get(user)
+                            .map(String::as_str)
+                            .unwrap_or("<none>"),
                         user = %user,
                         version = %version.unwrap_or("none"),
                         allowed = %self
@@ -564,21 +596,21 @@ impl Server {
             let routing_channel_for_callback = routing_channel_name.clone();
             let user_for_callback = user.clone();
             let registry = self.registry.clone();
+            let vpath_index = self.vpath_index.clone();
+            let user_names = self.user_names.clone();
+            let edit_bursts = self.edit_bursts.clone();
+            let client_versions = self.client_versions.clone();
             let doc_id_for_callback = doc_id.to_string();
-            // The parent pin lives in this closure, which the doc owns via
-            // its SyncKv observer: the guard detaches when the doc drops.
+            let semantic = self.semantic_logging;
             let _parent_guard = parent_guard;
 
             if let Some(dispatcher) = event_dispatcher {
                 Some(Arc::new(move |mut event: DocumentUpdatedEvent| {
-                    // Keep the parent pin alive by referencing it in the closure
                     let _ = &_parent_guard;
-                    // Add user to event if available
                     if let Some(ref user) = user_for_callback {
                         event.user = Some(user.clone());
                     }
 
-                    // Update parent's subdoc snapshot index
                     if routing_channel_for_callback != doc_id_for_callback {
                         if let Some(snapshot) = &event.snapshot {
                             if let Some(parent) = registry.peek(&routing_channel_for_callback) {
@@ -588,19 +620,167 @@ impl Server {
                         }
                     }
 
-                    // PUD registration and payload-driven PUD writes mutate
-                    // the doc under the server's own 53-bit client id. These
-                    // fire observe_update_v1 like any edit, but are internal
-                    // bookkeeping - not human-produced content changes.
-                    if event
-                        .update
-                        .as_deref()
-                        .is_some_and(edit_author::is_server_only_update)
-                    {
-                        let envelope =
-                            EventEnvelope::new(routing_channel_for_callback.clone(), event);
-                        dispatcher.send_event(envelope);
-                        return;
+                    let edited_doc_id = event.doc_id.as_str();
+                    let channel = event
+                        .metadata
+                        .get("channel")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or(&routing_channel_for_callback);
+
+                    if semantic {
+                        let editing_folder_doc = channel == edited_doc_id;
+                        let folder = if editing_folder_doc {
+                            None
+                        } else {
+                            registry.peek(channel)
+                        };
+
+                        if editing_folder_doc {
+                            if let Some(delta) = event.state.as_deref().and_then(|state| {
+                                vpath_index.sync_membership_from_snapshot(channel, state)
+                            }) {
+                                let by = match (&event.update, &event.state) {
+                                    (Some(update), Some(state)) => {
+                                        edit_author::user_from_snapshot(state, update)
+                                    }
+                                    _ => None,
+                                };
+                                let deleted_by = match (&event.update, &event.state) {
+                                    (Some(update), Some(state)) => {
+                                        edit_author::deleted_user_from_snapshot(state, update)
+                                    }
+                                    _ => None,
+                                };
+                                let deleted_clients = event
+                                    .update
+                                    .as_deref()
+                                    .map(edit_author::deleted_clients_for_update)
+                                    .unwrap_or_else(|| "-".to_string());
+                                // The captured first-load identity is a fair
+                                // stand-in only when nothing was deleted: a
+                                // deletion names no actor, and falling back
+                                // would misattribute it to whoever loaded the
+                                // folder doc first.
+                                let by = by.as_deref().or_else(|| {
+                                    (deleted_clients == "-")
+                                        .then_some(event.user.as_deref())
+                                        .flatten()
+                                });
+
+                                tracing::info!(
+                                    added = %delta.added.join(","),
+                                    removed = %delta.removed.join(","),
+                                    moved = %delta
+                                        .moved
+                                        .iter()
+                                        .map(|(from, to)| format!("{from}->{to}"))
+                                        .collect::<Vec<_>>()
+                                        .join(","),
+                                    name = %by
+                                        .and_then(|id| user_names.get(id))
+                                        .map(String::as_str)
+                                        .unwrap_or("<none>"),
+                                    user = %by.unwrap_or("-"),
+                                    clients = %event
+                                        .update
+                                        .as_deref()
+                                        .map(edit_author::clients_for_update)
+                                        .unwrap_or_else(|| "-".to_string()),
+                                    // Whose entries were removed - the owner of
+                                    // the deleted blocks. yjs records nothing
+                                    // about who removed them, so a removed= line
+                                    // with user=- is attributable no further.
+                                    deleted_name = %deleted_by
+                                        .as_deref()
+                                        .and_then(|id| user_names.get(id))
+                                        .map(String::as_str)
+                                        .unwrap_or("<none>"),
+                                    deleted_user = %deleted_by.as_deref().unwrap_or("-"),
+                                    deleted_clients = %deleted_clients,
+                                    channel = %channel,
+                                    "Folder membership changed"
+                                );
+                            }
+                        }
+
+                        let vpath = folder.and_then(|folder| {
+                            vpath_index.resolve(channel, &folder, edited_doc_id)
+                        });
+
+                        let author = match (&event.update, &event.state) {
+                            (Some(update), Some(state)) => {
+                                edit_author::user_from_snapshot(state, update)
+                            }
+                            _ => None,
+                        };
+
+                        // Same fallback gate as the membership line: an update
+                        // that deletes anything has no first-load stand-in.
+                        let deletes = event
+                            .update
+                            .as_deref()
+                            .map(edit_author::deleted_clients_for_update)
+                            .is_some_and(|deleted| deleted != "-");
+                        let user_id = author
+                            .as_deref()
+                            .or_else(|| (!deletes).then_some(event.user.as_deref()).flatten());
+                        let update_bytes = event.update.as_ref().map_or(0, Vec::len);
+                        let vpath_str = vpath.as_deref().unwrap_or("-");
+
+                        if event
+                            .update
+                            .as_deref()
+                            .is_some_and(edit_author::is_server_only_update)
+                        {
+                            let envelope =
+                                EventEnvelope::new(routing_channel_for_callback.clone(), event);
+                            dispatcher.send_event(envelope);
+                            return;
+                        }
+
+                        let edit_clients = event
+                            .update
+                            .as_deref()
+                            .map(edit_author::clients_in_update)
+                            .unwrap_or_default();
+                        if let Verdict::Leading = edit_bursts.record(edit_bursts::Edit {
+                            doc_id: edited_doc_id,
+                            user: user_id.unwrap_or("-"),
+                            vpath: vpath_str,
+                            channel,
+                            clients: &edit_clients,
+                            bytes: update_bytes,
+                        }) {
+                            tracing::info!(
+                                vpath = %vpath_str,
+                                name = %user_id
+                                    .and_then(|id| user_names.get(id))
+                                    .map(String::as_str)
+                                    .unwrap_or("<none>"),
+                                user = %user_id.unwrap_or("-"),
+                                version = %client_versions.describe(&edit_clients),
+                                clients = %edit_clients
+                                    .iter()
+                                    .map(u64::to_string)
+                                    .collect::<Vec<_>>()
+                                    .join(","),
+                                update_bytes,
+                                doc_id = %edited_doc_id,
+                                channel = %channel,
+                                "Doc edited"
+                            );
+                        }
+                    } else {
+                        if event
+                            .update
+                            .as_deref()
+                            .is_some_and(edit_author::is_server_only_update)
+                        {
+                            let envelope =
+                                EventEnvelope::new(routing_channel_for_callback.clone(), event);
+                            dispatcher.send_event(envelope);
+                            return;
+                        }
                     }
 
                     let envelope = EventEnvelope::new(routing_channel_for_callback.clone(), event);
@@ -624,7 +804,6 @@ impl Server {
         )
         .await?;
 
-        // If channel is provided in token, store it in document metadata
         if let Some(channel_name) = routing_channel {
             dwskv.set_channel(&channel_name);
         }
@@ -859,6 +1038,10 @@ impl Server {
             )
             .route("/webhook/reload", post(reload_webhook_config_endpoint));
 
+        if self.semantic_logging {
+            router = router.route("/client-versions", get(get_client_versions));
+        }
+
         // Only add file endpoints if a store is configured
         if let Some(store) = &self.store {
             // Add presigned URL endpoints for all stores
@@ -909,6 +1092,50 @@ impl Server {
         } else {
             app.layer(middleware::from_fn(Self::redact_error_middleware))
         };
+
+        if self.semantic_logging {
+            let bursts = self.edit_bursts.clone();
+            let burst_token = self.cancellation_token.clone();
+            let burst_user_names = self.user_names.clone();
+            let burst_client_versions = self.client_versions.clone();
+            let log_edit_bursts = move |finished: Vec<edit_bursts::FinishedBurst>| {
+                for burst in finished {
+                    tracing::info!(
+                        vpath = %burst.vpath,
+                        name = %burst_user_names
+                            .get(&burst.user)
+                            .map(String::as_str)
+                            .unwrap_or("<none>"),
+                        user = %burst.user,
+                        version = %burst_client_versions.describe(&burst.clients),
+                        clients = %burst
+                            .clients
+                            .iter()
+                            .map(u64::to_string)
+                            .collect::<Vec<_>>()
+                            .join(","),
+                        edits = burst.edits,
+                        update_bytes = burst.bytes,
+                        span_ms = burst.span.as_millis(),
+                        doc_id = %burst.doc_id,
+                        channel = %burst.channel,
+                        "Doc edit burst"
+                    );
+                }
+            };
+            tokio::spawn(async move {
+                let mut ticker = tokio::time::interval(edit_bursts::BURST_QUIET / 4);
+                loop {
+                    tokio::select! {
+                        _ = ticker.tick() => log_edit_bursts(bursts.take_finished()),
+                        _ = burst_token.cancelled() => {
+                            log_edit_bursts(bursts.drain_all());
+                            break;
+                        }
+                    }
+                }
+            });
+        }
 
         tracing::info!("Starting HTTP server...");
         axum::serve(listener, app.into_make_service())
@@ -1106,10 +1333,21 @@ async fn handle_socket_upgrade_with_channel_and_user(
     };
 
     let user_for_pud = user.clone();
+    let channel_for_vpath = routing_channel.clone();
     let guard = server_state
         .attach_doc(&doc_id, AttachKind::Socket, routing_channel, user)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    let vpath = channel_for_vpath.as_deref().and_then(|channel| {
+        server_state
+            .registry
+            .peek(channel)
+            .and_then(|folder| server_state.vpath_index.resolve(channel, &folder, &doc_id))
+    });
+    let user_name = user_for_pud
+        .as_deref()
+        .and_then(|id| server_state.user_names.get(id))
+        .cloned();
     let cancellation_token = server_state.doc_close_token.clone();
     let sync_protocol_event_sender = server_state.sync_protocol_event_sender.clone();
     let metrics = server_state.metrics.clone();
@@ -1120,11 +1358,12 @@ async fn handle_socket_upgrade_with_channel_and_user(
         let client_id = *client_id;
         let Some(v) = version.as_deref() else { break };
 
-        if let Some(recorded) = client_versions.declare(client_id, v) {
+        if let Some(recorded) = client_versions.declare(client_id, v, user_name.as_deref()) {
             tracing::debug!(
                 client_id,
                 version = %recorded.version,
                 previous = %recorded.previous.as_deref().unwrap_or(client_versions::UNKNOWN),
+                name = %user_name.as_deref().unwrap_or("-"),
                 doc_id = %doc_id,
                 "Recorded client version"
             );
@@ -1145,17 +1384,18 @@ async fn handle_socket_upgrade_with_channel_and_user(
             client_versions.observe(client_versions::Observation {
                 client_id: facts.client_id,
                 declared: facts.declared_version.as_deref(),
+                name: facts.user_name.as_deref(),
                 solo_live: facts.solo_live,
                 connection_version: version.as_deref(),
             }),
         )];
         if let Some(declared) = facts.declared_version.as_deref() {
-            recordings.extend(
-                facts
-                    .extra_client_ids
-                    .iter()
-                    .map(|extra| (*extra, client_versions.declare(*extra, declared))),
-            );
+            recordings.extend(facts.extra_client_ids.iter().map(|extra| {
+                (
+                    *extra,
+                    client_versions.declare(*extra, declared, facts.user_name.as_deref()),
+                )
+            }));
         }
         for (client_id, recorded) in recordings {
             let Some(recorded) = recorded else { continue };
@@ -1164,6 +1404,7 @@ async fn handle_socket_upgrade_with_channel_and_user(
                 client_id,
                 version = %recorded.version,
                 previous = %recorded.previous.as_deref().unwrap_or("-"),
+                name = %facts.user_name.as_deref().unwrap_or("-"),
                 doc_id = %doc_id_for_recorder,
                 "Recorded client version"
             );
@@ -1180,6 +1421,8 @@ async fn handle_socket_upgrade_with_channel_and_user(
             cancellation_token,
             sync_protocol_event_sender,
             doc_id_clone,
+            vpath,
+            user_name,
             metrics,
             record_client_version,
         )
@@ -1315,6 +1558,8 @@ async fn handle_socket(
     cancellation_token: CancellationToken,
     sync_protocol_event_sender: Arc<SyncProtocolEventSender>,
     doc_id: String,
+    vpath: Option<String>,
+    user_name: Option<String>,
     metrics: Arc<RelayMetrics>,
     record_client_version: ClientVersionRecorder,
 ) {
@@ -1329,6 +1574,8 @@ async fn handle_socket(
         cancellation_token,
         sync_protocol_event_sender,
         doc_id,
+        vpath,
+        user_name,
         metrics,
         record_client_version,
     )
@@ -1348,6 +1595,8 @@ async fn handle_socket_inner<S, T, E>(
     cancellation_token: CancellationToken,
     sync_protocol_event_sender: Arc<SyncProtocolEventSender>,
     doc_id: String,
+    vpath: Option<String>,
+    user_name: Option<String>,
     metrics: Arc<RelayMetrics>,
     record_client_version: ClientVersionRecorder,
 ) where
@@ -1429,6 +1678,12 @@ async fn handle_socket_inner<S, T, E>(
     conn.set_on_client_version(Box::new(move |facts| {
         record_client_version(facts);
     }));
+    if let Some(vpath) = vpath {
+        conn.set_vpath(vpath);
+    }
+    if let Some(user_name) = user_name {
+        conn.set_user_name(user_name);
+    }
     if let Some(user) = user {
         conn.set_user(user);
     }
@@ -1544,6 +1799,24 @@ async fn handle_socket_inner<S, T, E>(
     // was still holding — before the machine's park window can open.
     drop(connection);
     drop(guard);
+}
+
+async fn get_client_versions(
+    auth_header: Option<TypedHeader<headers::Authorization<headers::authorization::Bearer>>>,
+    State(server_state): State<Arc<Server>>,
+) -> Result<Json<Value>, AppError> {
+    server_state.check_auth(auth_header)?;
+
+    let entries = server_state.client_versions.snapshot();
+    Ok(Json(json!({
+        "count": entries.len(),
+        "client_versions": entries
+            .into_iter()
+            .map(|(client_id, version, name)| {
+                (client_id.to_string(), json!({"version": version, "name": name}))
+            })
+            .collect::<serde_json::Map<String, Value>>(),
+    })))
 }
 
 async fn check_store(
@@ -3746,6 +4019,8 @@ mod test {
                 server_token,
                 Arc::new(SyncProtocolEventSender::new()),
                 "test_doc".to_string(),
+                None,
+                None,
                 metrics.clone(),
                 Arc::new(|_| {}),
             ));

--- a/crates/relay/src/server.rs
+++ b/crates/relay/src/server.rs
@@ -1,4 +1,6 @@
+use crate::client_versions::{self, ClientVersions};
 use crate::doc_lifecycle::{AttachGuard, AttachKind, DocRegistry, LifecycleConfig};
+use crate::edit_author;
 use anyhow::{anyhow, Result};
 use axum::{
     body::Bytes,
@@ -22,7 +24,12 @@ use futures::{Sink, SinkExt, Stream, StreamExt, TryStreamExt};
 use serde::Deserialize;
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
-use std::{io::Write, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    io::Write,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
 use tempfile::NamedTempFile;
 use tokio::{
     net::TcpListener,
@@ -58,6 +65,8 @@ const PING_EVERY: Duration = Duration::from_secs(20);
 /// would-be keepalive reap. Observe-only: the connection is never closed for
 /// this; the metric exists to measure whether enforcement would be safe.
 const PONG_TIMEOUT: Duration = Duration::from_secs(40);
+
+const DENIAL_LOG_INTERVAL: Duration = Duration::from_secs(1800);
 
 #[derive(Clone, Debug)]
 pub struct AllowedHost {
@@ -238,6 +247,17 @@ pub struct Server {
     event_dispatcher: Option<Arc<dyn EventDispatcher>>,
     sync_protocol_event_sender: Arc<SyncProtocolEventSender>,
     metrics: Arc<RelayMetrics>,
+    allowed_client_versions: HashSet<String>,
+    denial_log_throttle: Mutex<HashMap<String, DenialLogState>>,
+    client_versions: Arc<ClientVersions>,
+}
+
+type ClientVersionRecorder =
+    Arc<dyn Fn(&y_sweet_core::doc_connection::AwarenessEntryFacts) + Send + Sync>;
+
+struct DenialLogState {
+    last_logged: Instant,
+    suppressed: u64,
 }
 
 impl Server {
@@ -308,7 +328,89 @@ impl Server {
             event_dispatcher,
             sync_protocol_event_sender,
             metrics,
+            allowed_client_versions: HashSet::new(),
+            denial_log_throttle: Mutex::new(HashMap::new()),
+            client_versions: Arc::new(ClientVersions::new()),
         })
+    }
+
+    pub fn with_allowed_client_versions(
+        mut self,
+        versions: impl IntoIterator<Item = String>,
+    ) -> Self {
+        self.allowed_client_versions = versions.into_iter().collect();
+        if !self.allowed_client_versions.is_empty() {
+            tracing::warn!(
+                "Requiring client version in {:?} for doc websocket access",
+                self.allowed_client_versions
+            );
+        }
+        self
+    }
+
+    fn denial_log_permit(&self, user: &str) -> Option<u64> {
+        let mut throttle = self.denial_log_throttle.lock().unwrap();
+        match throttle.get_mut(user) {
+            Some(state) if state.last_logged.elapsed() < DENIAL_LOG_INTERVAL => {
+                state.suppressed += 1;
+                None
+            }
+            Some(state) => {
+                let suppressed = state.suppressed;
+                state.last_logged = Instant::now();
+                state.suppressed = 0;
+                Some(suppressed)
+            }
+            None => {
+                throttle.insert(
+                    user.to_string(),
+                    DenialLogState {
+                        last_logged: Instant::now(),
+                        suppressed: 0,
+                    },
+                );
+                Some(0)
+            }
+        }
+    }
+
+    fn check_client_version(
+        &self,
+        user: Option<&str>,
+        version: Option<&str>,
+    ) -> Result<(), AppError> {
+        let Some(user) = user else {
+            return Ok(());
+        };
+        if self.allowed_client_versions.is_empty() {
+            return Ok(());
+        }
+
+        match version {
+            Some(v) if self.allowed_client_versions.contains(v) => Ok(()),
+            _ => {
+                if let Some(suppressed) = self.denial_log_permit(user) {
+                    tracing::warn!(
+                        user = %user,
+                        version = %version.unwrap_or("none"),
+                        allowed = %self
+                            .allowed_client_versions
+                            .iter()
+                            .cloned()
+                            .collect::<Vec<_>>()
+                            .join(","),
+                        suppressed,
+                        interval_secs = DENIAL_LOG_INTERVAL.as_secs(),
+                        "Blocked user on client version"
+                    );
+                }
+                Err(AppError::auth(
+                    StatusCode::FORBIDDEN,
+                    anyhow!("This plugin version is temporarily blocked from sync; run witchdoctor to upgrade"),
+                    "client_version_blocked",
+                ))
+            }
+        }
     }
 
     /// Close every doc WebSocket: each socket loop breaks, sends its
@@ -486,23 +588,22 @@ impl Server {
                         }
                     }
 
-                    // Log the full event payload as JSON after user assignment
-                    match serde_json::to_string(&event) {
-                        Ok(json_str) => {
-                            tracing::info!("Document updated event dispatched: {}", json_str);
-                        }
-                        Err(e) => {
-                            tracing::info!(
-                                "Document updated event dispatched for doc_id: {} (JSON serialization failed: {})",
-                                event.doc_id, e
-                            );
-                        }
+                    // PUD registration and payload-driven PUD writes mutate
+                    // the doc under the server's own 53-bit client id. These
+                    // fire observe_update_v1 like any edit, but are internal
+                    // bookkeeping - not human-produced content changes.
+                    if event
+                        .update
+                        .as_deref()
+                        .is_some_and(edit_author::is_server_only_update)
+                    {
+                        let envelope =
+                            EventEnvelope::new(routing_channel_for_callback.clone(), event);
+                        dispatcher.send_event(envelope);
+                        return;
                     }
 
-                    // Step 1: Create the envelope with predetermined routing channel
                     let envelope = EventEnvelope::new(routing_channel_for_callback.clone(), event);
-
-                    // Step 2: Send via dispatcher
                     dispatcher.send_event(envelope);
                 }) as y_sweet_core::webhook::WebhookCallback)
             } else {
@@ -884,6 +985,17 @@ impl Server {
 #[derive(Deserialize)]
 struct HandlerParams {
     token: Option<String>,
+    v: Option<String>,
+    cid: Option<String>,
+}
+
+impl HandlerParams {
+    fn declared_client_ids(&self) -> Vec<u64> {
+        self.cid
+            .as_deref()
+            .map(|cid| cid.split(',').filter_map(|id| id.parse().ok()).collect())
+            .unwrap_or_default()
+    }
 }
 
 async fn get_doc_as_update(
@@ -962,6 +1074,7 @@ async fn update_doc_inner(
     Ok(StatusCode::OK.into_response())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn handle_socket_upgrade_with_channel_and_user(
     ws: WebSocketUpgrade,
     Path(doc_id): Path<String>,
@@ -969,6 +1082,8 @@ async fn handle_socket_upgrade_with_channel_and_user(
     routing_channel: Option<String>,
     user: Option<String>,
     token: Option<String>,
+    version: Option<String>,
+    declared_client_ids: Vec<u64>,
     State(server_state): State<Arc<Server>>,
 ) -> Result<Response, AppError> {
     server_state
@@ -995,15 +1110,66 @@ async fn handle_socket_upgrade_with_channel_and_user(
         .attach_doc(&doc_id, AttachKind::Socket, routing_channel, user)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
-    // Socket loops watch the doc-close token (a child of the server token)
-    // so shutdown can close them ahead of the graceful drain.
     let cancellation_token = server_state.doc_close_token.clone();
     let sync_protocol_event_sender = server_state.sync_protocol_event_sender.clone();
     let metrics = server_state.metrics.clone();
     let doc_id_clone = doc_id.clone();
+    let client_versions = server_state.client_versions.clone();
+    let doc_id_for_recorder = doc_id.clone();
+    for client_id in &declared_client_ids {
+        let client_id = *client_id;
+        let Some(v) = version.as_deref() else { break };
 
-    // The guard moves into the upgrade closure: an abandoned upgrade
-    // detaches via RAII.
+        if let Some(recorded) = client_versions.declare(client_id, v) {
+            tracing::debug!(
+                client_id,
+                version = %recorded.version,
+                previous = %recorded.previous.as_deref().unwrap_or(client_versions::UNKNOWN),
+                doc_id = %doc_id,
+                "Recorded client version"
+            );
+        }
+        if let (Some(user), true) = (user_for_pud.as_deref(), client_id >> 53 == 0) {
+            let awareness = guard.awareness();
+            let awareness = awareness.read().unwrap();
+            y_sweet_core::doc_connection::DocConnection::register_pud_client_id_on_doc(
+                awareness.doc(),
+                user,
+                yrs::block::ClientID::new(client_id),
+            );
+        }
+    }
+    let record_client_version: ClientVersionRecorder = Arc::new(move |facts| {
+        let mut recordings = vec![(
+            facts.client_id,
+            client_versions.observe(client_versions::Observation {
+                client_id: facts.client_id,
+                declared: facts.declared_version.as_deref(),
+                solo_live: facts.solo_live,
+                connection_version: version.as_deref(),
+            }),
+        )];
+        if let Some(declared) = facts.declared_version.as_deref() {
+            recordings.extend(
+                facts
+                    .extra_client_ids
+                    .iter()
+                    .map(|extra| (*extra, client_versions.declare(*extra, declared))),
+            );
+        }
+        for (client_id, recorded) in recordings {
+            let Some(recorded) = recorded else { continue };
+
+            tracing::debug!(
+                client_id,
+                version = %recorded.version,
+                previous = %recorded.previous.as_deref().unwrap_or("-"),
+                doc_id = %doc_id_for_recorder,
+                "Recorded client version"
+            );
+        }
+    });
+
     Ok(ws.on_upgrade(move |socket| {
         handle_socket(
             socket,
@@ -1015,6 +1181,7 @@ async fn handle_socket_upgrade_with_channel_and_user(
             sync_protocol_event_sender,
             doc_id_clone,
             metrics,
+            record_client_version,
         )
     }))
 }
@@ -1088,6 +1255,7 @@ async fn handle_socket_upgrade_deprecated(
     );
     let (authorization, channel, user) =
         verify_socket_token(&server_state, &doc_id, params.token.as_deref())?;
+    server_state.check_client_version(user.as_deref(), params.v.as_deref())?;
 
     handle_socket_upgrade_with_channel_and_user(
         ws,
@@ -1095,7 +1263,9 @@ async fn handle_socket_upgrade_deprecated(
         authorization,
         channel,
         user,
-        params.token.clone(), // Pass the token from query params
+        params.token.clone(),
+        params.v.clone(),
+        params.declared_client_ids(),
         State(server_state),
     )
     .await
@@ -1119,6 +1289,7 @@ async fn handle_socket_upgrade_full_path(
 
     let (authorization, channel, user) =
         verify_socket_token(&server_state, &doc_id, params.token.as_deref())?;
+    server_state.check_client_version(user.as_deref(), params.v.as_deref())?;
 
     handle_socket_upgrade_with_channel_and_user(
         ws,
@@ -1126,12 +1297,15 @@ async fn handle_socket_upgrade_full_path(
         authorization,
         channel,
         user,
-        params.token.clone(), // Pass the token from query params
+        params.token.clone(),
+        params.v.clone(),
+        params.declared_client_ids(),
         State(server_state),
     )
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn handle_socket(
     socket: WebSocket,
     guard: AttachGuard,
@@ -1142,6 +1316,7 @@ async fn handle_socket(
     sync_protocol_event_sender: Arc<SyncProtocolEventSender>,
     doc_id: String,
     metrics: Arc<RelayMetrics>,
+    record_client_version: ClientVersionRecorder,
 ) {
     let (sink, stream) = socket.split();
     handle_socket_inner(
@@ -1155,6 +1330,7 @@ async fn handle_socket(
         sync_protocol_event_sender,
         doc_id,
         metrics,
+        record_client_version,
     )
     .await
 }
@@ -1173,6 +1349,7 @@ async fn handle_socket_inner<S, T, E>(
     sync_protocol_event_sender: Arc<SyncProtocolEventSender>,
     doc_id: String,
     metrics: Arc<RelayMetrics>,
+    record_client_version: ClientVersionRecorder,
 ) where
     S: Sink<Message> + Send + Unpin + 'static,
     T: Stream<Item = Result<Message, E>> + Unpin,
@@ -1248,6 +1425,10 @@ async fn handle_socket_inner<S, T, E>(
         },
     );
     conn.set_sync_kv(sync_kv);
+    conn.set_doc_id(doc_id.clone());
+    conn.set_on_client_version(Box::new(move |facts| {
+        record_client_version(facts);
+    }));
     if let Some(user) = user {
         conn.set_user(user);
     }
@@ -3566,6 +3747,7 @@ mod test {
                 Arc::new(SyncProtocolEventSender::new()),
                 "test_doc".to_string(),
                 metrics.clone(),
+                Arc::new(|_| {}),
             ));
 
             SocketHarness {

--- a/crates/relay/src/vpath_index.rs
+++ b/crates/relay/src/vpath_index.rs
@@ -1,0 +1,605 @@
+//! Resolve a document GUID to the vault-relative path its shared folder knows
+//! it by.
+//!
+//! Every log line the server emits carries a doc GUID and no path, which makes
+//! an edit log readable only to someone who can already map GUIDs to notes.
+//! The mapping exists server-side: a shared folder's `filemeta_v0` map is keyed
+//! by vpath, and each value carries the child's GUID under `id`. This module
+//! inverts that map and caches the result per folder.
+//!
+//! The cache is invalidated by the folder doc's update count rather than by
+//! time, so a lookup after a rename resolves to the new path on the first
+//! update that follows it.
+//!
+//! Both entry points run from update callbacks, which fire inside
+//! `apply_update` while the edited doc's awareness lock is held as a writer.
+//! A blocking read of that lock deadlocks the doc. `resolve` therefore reads
+//! the *parent* folder under `try_read` and gives up rather than block, and
+//! the membership diff, whose folder is the edited doc itself, reads the
+//! post-update snapshot the event already carries instead of the live doc.
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+use y_sweet_core::doc_sync::DocWithSyncKv;
+use yrs::updates::decoder::Decode;
+use yrs::{Map, Out, ReadTxn, Transact};
+
+const FILEMETA_ROOT: &str = "filemeta_v0";
+
+/// One entry per shared folder that has seen an edit. A server hosts far fewer
+/// folders than this, so the bound only matters as a backstop against folder
+/// ids accumulating across evictions and reloads.
+const MAX_CACHED_FOLDERS: usize = 256;
+
+/// A folder's GUID -> vpath mapping, plus the marker identifying the folder
+/// state it was built from.
+struct CachedIndex {
+    by_guid: HashMap<String, String>,
+    built_from: FolderMarker,
+}
+
+/// Cheap stand-in for "has this folder's membership changed". The state vector
+/// would be exact but costs an encode per lookup; entry count plus the folder's
+/// own clock moves on any add, remove, or rename.
+#[derive(PartialEq, Clone, Copy)]
+struct FolderMarker {
+    entries: usize,
+    clock: u64,
+}
+
+pub struct VPathIndex {
+    by_folder: RwLock<HashMap<String, CachedIndex>>,
+    /// Last membership reported per folder, deliberately separate from
+    /// `by_folder`. Adding a file writes two updates - the child doc and the
+    /// folder doc - and the child arrives first, calling `resolve`, which
+    /// refreshes `by_folder`. Sharing one map let that refresh overwrite the
+    /// baseline the diff reads as "before", so every add reported no change.
+    membership: RwLock<HashMap<String, HashMap<String, String>>>,
+}
+
+impl Default for VPathIndex {
+    fn default() -> Self {
+        Self {
+            by_folder: RwLock::new(HashMap::new()),
+            membership: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+fn folder_marker(folder: &DocWithSyncKv) -> Option<FolderMarker> {
+    let aw = folder.awareness();
+    let aw = aw.try_read().ok()?;
+    let txn = aw.doc.transact();
+    if !txn.root_refs().any(|(name, _)| name == FILEMETA_ROOT) {
+        return None;
+    }
+
+    Some(FolderMarker {
+        entries: txn
+            .get_map(FILEMETA_ROOT)
+            .map_or(0, |m| m.len(&txn) as usize),
+        clock: txn
+            .state_vector()
+            .iter()
+            .map(|(_, clock)| u64::from(*clock))
+            .sum(),
+    })
+}
+
+fn build_index(folder: &DocWithSyncKv) -> HashMap<String, String> {
+    let Some(aw) = folder.awareness().try_read().ok().map(|aw| aw.doc.clone()) else {
+        return HashMap::new();
+    };
+
+    let txn = aw.transact();
+    index_from_txn(&txn)
+}
+
+fn index_from_txn<T: ReadTxn>(txn: &T) -> HashMap<String, String> {
+    let Some(filemeta) = txn.get_map(FILEMETA_ROOT) else {
+        return HashMap::new();
+    };
+
+    filemeta
+        .iter(txn)
+        .filter_map(|(path, value)| match value {
+            Out::Any(yrs::Any::Map(fields)) => match fields.get("id") {
+                Some(yrs::Any::String(guid)) => Some((guid.to_string(), path.to_string())),
+                _ => None,
+            },
+            _ => None,
+        })
+        .collect()
+}
+
+/// Doc ids on the wire are `<relay_id>-<guid>`, but `filemeta_v0` keys its
+/// entries on the bare guid. The folder's own id carries the same relay
+/// prefix, so it identifies the part to drop.
+///
+/// Returns `doc_id` unchanged when the two share no prefix, which covers
+/// single-segment ids in tests and any future unprefixed scheme.
+fn strip_relay_prefix<'a>(doc_id: &'a str, folder_id: &str) -> &'a str {
+    // A UUID is five dash-separated groups, so a prefixed id has ten and the
+    // relay portion ends just before the sixth.
+    let Some(relay_prefix) = folder_id
+        .match_indices('-')
+        .nth(4)
+        .map(|(i, _)| &folder_id[..i])
+    else {
+        return doc_id;
+    };
+
+    doc_id
+        .strip_prefix(relay_prefix)
+        .and_then(|rest| rest.strip_prefix('-'))
+        .unwrap_or(doc_id)
+}
+
+/// How a shared folder's membership changed between two observations.
+#[derive(Debug, Default, PartialEq)]
+pub struct MembershipDelta {
+    pub added: Vec<String>,
+    pub removed: Vec<String>,
+    /// `(from, to)`. A GUID present on both sides under different paths is a
+    /// move, never a remove plus an add.
+    pub moved: Vec<(String, String)>,
+}
+
+impl MembershipDelta {
+    fn is_empty(&self) -> bool {
+        self.added.is_empty() && self.removed.is_empty() && self.moved.is_empty()
+    }
+}
+
+fn diff_membership(
+    before: &HashMap<String, String>,
+    after: &HashMap<String, String>,
+) -> MembershipDelta {
+    let mut delta = MembershipDelta::default();
+
+    for (guid, path) in after {
+        match before.get(guid) {
+            None => delta.added.push(path.clone()),
+            Some(prior) if prior != path => delta.moved.push((prior.clone(), path.clone())),
+            Some(_) => {}
+        }
+    }
+    for (guid, path) in before {
+        if !after.contains_key(guid) {
+            delta.removed.push(path.clone());
+        }
+    }
+
+    // Folder walks are unordered, so sort to keep a line stable across runs.
+    delta.added.sort();
+    delta.removed.sort();
+    delta.moved.sort();
+    delta
+}
+
+impl VPathIndex {
+    /// The vpath `folder` knows `doc_id` by, or None when the folder has no
+    /// `filemeta_v0` yet or does not list this child.
+    ///
+    /// Rebuilds the folder's index when its membership marker has moved, so a
+    /// caller on the update path pays a full map walk only after a change.
+    pub fn resolve(&self, folder_id: &str, folder: &DocWithSyncKv, doc_id: &str) -> Option<String> {
+        let doc_id = strip_relay_prefix(doc_id, folder_id);
+        let marker = folder_marker(folder)?;
+
+        if let Ok(cache) = self.by_folder.read() {
+            if let Some(cached) = cache.get(folder_id) {
+                if cached.built_from == marker {
+                    return cached.by_guid.get(doc_id).cloned();
+                }
+            }
+        }
+
+        let by_guid = build_index(folder);
+        let resolved = by_guid.get(doc_id).cloned();
+        if let Ok(mut cache) = self.by_folder.write() {
+            if cache.len() >= MAX_CACHED_FOLDERS && !cache.contains_key(folder_id) {
+                cache.clear();
+            }
+            cache.insert(
+                folder_id.to_string(),
+                CachedIndex {
+                    by_guid,
+                    built_from: marker,
+                },
+            );
+        }
+
+        resolved
+    }
+
+    /// Refresh `folder_id`'s mapping and report how membership changed since
+    /// the last call.
+    ///
+    /// Returns None the first time a folder is seen: with no prior mapping,
+    /// every entry would look like an add, and reporting a folder's whole
+    /// contents as new on load is worse than staying quiet.
+    ///
+    /// Reads the folder state from the post-update snapshot the event already
+    /// carries, rather than from the live doc: this runs from an update
+    /// observer, where the folder's awareness lock is held as a writer and
+    /// re-reading it would deadlock.
+    pub fn sync_membership_from_snapshot(
+        &self,
+        folder_id: &str,
+        snapshot: &[u8],
+    ) -> Option<MembershipDelta> {
+        let doc = yrs::Doc::new();
+        {
+            let mut txn = doc.transact_mut();
+            txn.apply_update(yrs::Update::decode_v1(snapshot).ok()?)
+                .ok()?;
+        }
+        let txn = doc.transact();
+
+        let marker = FolderMarker {
+            entries: txn
+                .get_map(FILEMETA_ROOT)
+                .map_or(0, |m| m.len(&txn) as usize),
+            clock: txn
+                .state_vector()
+                .iter()
+                .map(|(_, clock)| u64::from(*clock))
+                .sum(),
+        };
+        let by_guid = index_from_txn(&txn);
+
+        // Diff against the membership baseline, which only this method writes.
+        let mut baseline = self.membership.write().ok()?;
+        let delta = baseline
+            .get(folder_id)
+            .map(|before| diff_membership(before, &by_guid));
+
+        if baseline.len() >= MAX_CACHED_FOLDERS && !baseline.contains_key(folder_id) {
+            baseline.clear();
+        }
+        baseline.insert(folder_id.to_string(), by_guid.clone());
+
+        // Refresh the resolver cache too: this snapshot is newer than whatever
+        // it holds, and a child edit that follows should see the new entry.
+        if let Ok(mut cache) = self.by_folder.write() {
+            if cache.len() >= MAX_CACHED_FOLDERS && !cache.contains_key(folder_id) {
+                cache.clear();
+            }
+            cache.insert(
+                folder_id.to_string(),
+                CachedIndex {
+                    by_guid,
+                    built_from: marker,
+                },
+            );
+        }
+
+        delta.filter(|d| !d.is_empty())
+    }
+
+    /// Drop a folder's cached mapping. Called when a folder doc is evicted so
+    /// the cache does not outlive the docs it describes.
+    pub fn forget(&self, folder_id: &str) {
+        if let Ok(mut cache) = self.by_folder.write() {
+            cache.remove(folder_id);
+        }
+        if let Ok(mut baseline) = self.membership.write() {
+            baseline.remove(folder_id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use yrs::Any;
+
+    async fn folder_with(entries: &[(&str, &str)]) -> DocWithSyncKv {
+        let folder = DocWithSyncKv::new("folder", None, || (), None)
+            .await
+            .unwrap();
+        write_entries(&folder, entries);
+        folder
+    }
+
+    fn write_entries(folder: &DocWithSyncKv, entries: &[(&str, &str)]) {
+        let aw = folder.awareness();
+        let aw = aw.read().unwrap();
+        let map = aw.doc().get_or_insert_map(FILEMETA_ROOT);
+        let mut txn = aw.doc().transact_mut();
+        for (path, guid) in entries {
+            map.insert(
+                &mut txn,
+                *path,
+                Any::from(std::collections::HashMap::from([(
+                    "id".to_string(),
+                    Any::String((*guid).into()),
+                )])),
+            );
+        }
+    }
+
+    /// The encoded post-update state, matching what the update observer hands
+    /// the callback as `event.snapshot`.
+    fn snapshot_of(folder: &DocWithSyncKv) -> Vec<u8> {
+        let aw = folder.awareness();
+        let aw = aw.read().unwrap();
+        let txn = aw.doc().transact();
+        txn.encode_state_as_update_v1(&yrs::StateVector::default())
+    }
+
+    fn remove_entry(folder: &DocWithSyncKv, path: &str) {
+        let aw = folder.awareness();
+        let aw = aw.read().unwrap();
+        let map = aw.doc().get_or_insert_map(FILEMETA_ROOT);
+        let mut txn = aw.doc().transact_mut();
+        map.remove(&mut txn, path);
+    }
+
+    #[tokio::test]
+    async fn resolves_a_guid_to_the_path_its_folder_lists_it_under() {
+        let folder = folder_with(&[("notes/today.md", "guid-a"), ("refs/spec.md", "guid-b")]).await;
+
+        assert_eq!(
+            VPathIndex::default().resolve("folder", &folder, "guid-b"),
+            Some("refs/spec.md".to_string())
+        );
+    }
+
+    /// Production ids are `<relay_id>-<guid>` while filemeta_v0 is keyed on
+    /// the bare guid. Resolving the wire id against that map is the real
+    /// case; tests that use the same string for both never exercise it.
+    #[tokio::test]
+    async fn resolves_a_relay_prefixed_doc_id() {
+        const RELAY: &str = "26120033-7a40-4583-809d-a1b151dddc5d";
+        let guid = "d1c3dc2b-ac71-4f5c-a19b-a87ec06b6665";
+        let folder = folder_with(&[("notes/prefixed.md", guid)]).await;
+
+        assert_eq!(
+            VPathIndex::default().resolve(
+                &format!("{RELAY}-f8c9593b-f62b-41dc-911b-8b73cf1372c2"),
+                &folder,
+                &format!("{RELAY}-{guid}"),
+            ),
+            Some("notes/prefixed.md".to_string())
+        );
+    }
+
+    #[test]
+    fn strip_relay_prefix_leaves_unprefixed_ids_alone() {
+        assert_eq!(strip_relay_prefix("child-doc", "parent-doc"), "child-doc");
+        assert_eq!(
+            strip_relay_prefix("26120033-7a40-4583-809d-a1b151dddc5d-abc", "short-id"),
+            "26120033-7a40-4583-809d-a1b151dddc5d-abc",
+            "a folder id with no relay prefix cannot identify one to strip"
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_guid_resolves_to_none() {
+        let folder = folder_with(&[("notes/today.md", "guid-a")]).await;
+
+        assert_eq!(
+            VPathIndex::default().resolve("folder", &folder, "guid-missing"),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn folder_without_filemeta_resolves_to_none() {
+        let folder = DocWithSyncKv::new("folder", None, || (), None)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            VPathIndex::default().resolve("folder", &folder, "guid-a"),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn a_rename_is_picked_up_on_the_next_lookup() {
+        let folder = folder_with(&[("notes/old-name.md", "guid-a")]).await;
+        let index = VPathIndex::default();
+        assert_eq!(
+            index.resolve("folder", &folder, "guid-a"),
+            Some("notes/old-name.md".to_string())
+        );
+
+        remove_entry(&folder, "notes/old-name.md");
+        write_entries(&folder, &[("notes/new-name.md", "guid-a")]);
+
+        assert_eq!(
+            index.resolve("folder", &folder, "guid-a"),
+            Some("notes/new-name.md".to_string()),
+            "a cached index must not outlive the rename that invalidated it"
+        );
+    }
+
+    #[tokio::test]
+    async fn membership_reads_do_not_touch_the_live_doc_lock() {
+        // Update callbacks run with the doc's awareness lock held as a writer.
+        // Holding it here reproduces that: anything that reads the live doc
+        // instead of the snapshot hangs the test rather than failing it.
+        let folder = folder_with(&[("notes/a.md", "guid-a")]).await;
+        let index = VPathIndex::default();
+        let before = snapshot_of(&folder);
+        index.sync_membership_from_snapshot("folder", &before);
+
+        write_entries(&folder, &[("notes/b.md", "guid-b")]);
+        let after = snapshot_of(&folder);
+
+        let aw = folder.awareness();
+        let _writer = aw.write().unwrap();
+
+        assert_eq!(
+            index.sync_membership_from_snapshot("folder", &after),
+            Some(MembershipDelta {
+                added: vec!["notes/b.md".to_string()],
+                ..Default::default()
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn first_sight_of_a_folder_reports_no_delta() {
+        let folder = folder_with(&[("notes/a.md", "guid-a")]).await;
+
+        assert_eq!(
+            VPathIndex::default().sync_membership_from_snapshot("folder", &snapshot_of(&folder)),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unchanged_folder_reports_no_delta() {
+        let folder = folder_with(&[("notes/a.md", "guid-a")]).await;
+        let index = VPathIndex::default();
+        index.sync_membership_from_snapshot("folder", &snapshot_of(&folder));
+
+        assert_eq!(
+            index.sync_membership_from_snapshot("folder", &snapshot_of(&folder)),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn a_new_file_is_reported_as_an_add() {
+        let folder = folder_with(&[("notes/a.md", "guid-a")]).await;
+        let index = VPathIndex::default();
+        index.sync_membership_from_snapshot("folder", &snapshot_of(&folder));
+
+        write_entries(&folder, &[("notes/b.md", "guid-b")]);
+
+        assert_eq!(
+            index.sync_membership_from_snapshot("folder", &snapshot_of(&folder)),
+            Some(MembershipDelta {
+                added: vec!["notes/b.md".to_string()],
+                ..Default::default()
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn a_deleted_file_is_reported_as_a_remove() {
+        let folder = folder_with(&[("notes/a.md", "guid-a"), ("notes/b.md", "guid-b")]).await;
+        let index = VPathIndex::default();
+        index.sync_membership_from_snapshot("folder", &snapshot_of(&folder));
+
+        remove_entry(&folder, "notes/b.md");
+
+        assert_eq!(
+            index.sync_membership_from_snapshot("folder", &snapshot_of(&folder)),
+            Some(MembershipDelta {
+                removed: vec!["notes/b.md".to_string()],
+                ..Default::default()
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn a_move_is_not_reported_as_a_delete_plus_an_add() {
+        let folder = folder_with(&[("notes/a.md", "guid-a")]).await;
+        let index = VPathIndex::default();
+        index.sync_membership_from_snapshot("folder", &snapshot_of(&folder));
+
+        remove_entry(&folder, "notes/a.md");
+        write_entries(&folder, &[("archive/a.md", "guid-a")]);
+
+        assert_eq!(
+            index.sync_membership_from_snapshot("folder", &snapshot_of(&folder)),
+            Some(MembershipDelta {
+                moved: vec![("notes/a.md".to_string(), "archive/a.md".to_string())],
+                ..Default::default()
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn an_added_sibling_invalidates_the_cache() {
+        let folder = folder_with(&[("notes/a.md", "guid-a")]).await;
+        let index = VPathIndex::default();
+        assert_eq!(index.resolve("folder", &folder, "guid-b"), None);
+
+        write_entries(&folder, &[("notes/b.md", "guid-b")]);
+
+        assert_eq!(
+            index.resolve("folder", &folder, "guid-b"),
+            Some("notes/b.md".to_string())
+        );
+    }
+
+    /// The production interleaving: a child edit calls resolve() between two
+    /// folder edits. resolve() refreshes the same cache the membership diff
+    /// reads as its "before", so an add can be erased before it is ever
+    /// reported.
+    #[tokio::test]
+    async fn a_resolve_between_folder_edits_must_not_swallow_the_add() {
+        let folder = folder_with(&[("notes/a.md", "guid-a")]).await;
+        let index = VPathIndex::default();
+        index.sync_membership_from_snapshot("folder", &snapshot_of(&folder));
+
+        // A file appears: the folder gains an entry, and the new child doc
+        // gets edited too - which is what calls resolve().
+        write_entries(&folder, &[("notes/b.md", "guid-b")]);
+        index.resolve("folder", &folder, "guid-b");
+
+        assert_eq!(
+            index.sync_membership_from_snapshot("folder", &snapshot_of(&folder)),
+            Some(MembershipDelta {
+                added: vec!["notes/b.md".to_string()],
+                ..Default::default()
+            }),
+            "resolve() must not consume the baseline the membership diff needs"
+        );
+    }
+
+    /// `event.snapshot` is `txn.snapshot().encode_v1()` - a yrs Snapshot
+    /// (state vector + delete set), not a document update. Decoding it as an
+    /// update yields an empty doc, so the membership diff has been reading an
+    /// empty filemeta map the whole time.
+    #[tokio::test]
+    async fn a_yrs_snapshot_is_not_a_document_update() {
+        use yrs::updates::encoder::Encode;
+        let folder = folder_with(&[("notes/a.md", "guid-a")]).await;
+
+        let (as_snapshot, as_update) = {
+            let aw = folder.awareness();
+            let aw = aw.read().unwrap();
+            let txn = aw.doc().transact();
+            (
+                txn.snapshot().encode_v1(),
+                txn.encode_state_as_update_v1(&yrs::StateVector::default()),
+            )
+        };
+
+        let index = VPathIndex::default();
+        index.sync_membership_from_snapshot("folder", &as_update);
+        assert_eq!(
+            index
+                .membership
+                .read()
+                .unwrap()
+                .get("folder")
+                .map(|m| m.len()),
+            Some(1),
+            "a real update carries the filemeta entries"
+        );
+
+        let from_snapshot = VPathIndex::default();
+        from_snapshot.sync_membership_from_snapshot("folder", &as_snapshot);
+        // Decoding a Snapshot as an update fails outright, so the method
+        // returns early and never records a baseline at all.
+        assert_eq!(
+            from_snapshot
+                .membership
+                .read()
+                .unwrap()
+                .get("folder")
+                .map(|m| m.len()),
+            None,
+            "a yrs Snapshot is not decodable as an update, which is what production passes"
+        );
+    }
+}

--- a/crates/y-sweet-core/src/config.rs
+++ b/crates/y-sweet-core/src/config.rs
@@ -299,6 +299,13 @@ pub struct ServerConfig {
 
     #[serde(default = "default_redact_errors")]
     pub redact_errors: bool,
+
+    /// When non-empty, doc websocket connections must report one of these
+    /// plugin versions (`v` query param, sent by clients >= 0.8.8);
+    /// anything else - including clients too old to report - gets 403.
+    /// Server tokens are exempt. Empty = no version gating.
+    #[serde(default)]
+    pub allowed_client_versions: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -590,6 +597,7 @@ impl Default for ServerConfig {
             checkpoint_freq_seconds: default_checkpoint_freq_seconds(),
             doc_gc: default_doc_gc(),
             redact_errors: default_redact_errors(),
+            allowed_client_versions: Vec::new(),
         }
     }
 }
@@ -1214,5 +1222,35 @@ public_key = "test-public-key"
         let (key, types) = parse_auth_env_value("abc123base64key==").unwrap();
         assert_eq!(key, "abc123base64key==");
         assert_eq!(types, default_allowed_token_types());
+    }
+
+    #[test]
+    fn allowed_client_versions_are_optional() {
+        let config: Config = toml::from_str(
+            r#"
+[server]
+url = "https://example.com"
+"#,
+        )
+        .expect("a config with no allowed_client_versions must still parse");
+
+        assert!(config.server.allowed_client_versions.is_empty());
+    }
+
+    #[test]
+    fn allowed_client_versions_parse() {
+        let config: Config = toml::from_str(
+            r#"
+[server]
+url = "https://example.com"
+allowed_client_versions = ["0.9.3", "0.9.2"]
+"#,
+        )
+        .expect("config with allowed_client_versions must parse");
+
+        assert_eq!(
+            config.server.allowed_client_versions,
+            vec!["0.9.3", "0.9.2"]
+        );
     }
 }

--- a/crates/y-sweet-core/src/config.rs
+++ b/crates/y-sweet-core/src/config.rs
@@ -306,6 +306,22 @@ pub struct ServerConfig {
     /// Server tokens are exempt. Empty = no version gating.
     #[serde(default)]
     pub allowed_client_versions: Vec<String>,
+
+    /// Enables edit attribution logging, vpath resolution, folder membership
+    /// change tracking, the /client-versions endpoint, and user display names
+    /// in log lines. Default false: without it the server logs only opaque ids
+    /// and behavioral events. Self-hosters who want operational visibility into
+    /// who edited what opt in here.
+    #[serde(default)]
+    pub semantic_logging: bool,
+
+    /// Relay user id -> display name, for log readability only. The server has
+    /// no other source for a name: tokens carry an opaque id and nothing else.
+    /// Ids absent from the map log `name=<none>`, and an empty map behaves the
+    /// same as not configuring one. Never consulted for authorization.
+    /// Only takes effect when `semantic_logging` is true.
+    #[serde(default)]
+    pub user_names: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -598,6 +614,8 @@ impl Default for ServerConfig {
             doc_gc: default_doc_gc(),
             redact_errors: default_redact_errors(),
             allowed_client_versions: Vec::new(),
+            semantic_logging: false,
+            user_names: HashMap::new(),
         }
     }
 }
@@ -1252,5 +1270,38 @@ allowed_client_versions = ["0.9.3", "0.9.2"]
             config.server.allowed_client_versions,
             vec!["0.9.3", "0.9.2"]
         );
+    }
+
+    #[test]
+    fn user_names_parse_from_a_server_subtable() {
+        let config: Config = toml::from_str(
+            r#"
+[server]
+url = "https://example.com"
+
+[server.user_names]
+"abc123" = "Ada Lovelace"
+"#,
+        )
+        .expect("config with a user_names table must parse");
+
+        assert_eq!(
+            config.server.user_names.get("abc123").map(String::as_str),
+            Some("Ada Lovelace")
+        );
+        assert_eq!(config.server.user_names.get("nobody"), None);
+    }
+
+    #[test]
+    fn user_names_are_optional() {
+        let config: Config = toml::from_str(
+            r#"
+[server]
+url = "https://example.com"
+"#,
+        )
+        .expect("a config with no user_names must still parse");
+
+        assert!(config.server.user_names.is_empty());
     }
 }

--- a/crates/y-sweet-core/src/doc_connection.rs
+++ b/crates/y-sweet-core/src/doc_connection.rs
@@ -81,6 +81,26 @@ type ClientVersionCallback = Box<dyn Fn(&AwarenessEntryFacts) + Send + Sync>;
 
 const SYNC_STATUS_MESSAGE: u8 = 102;
 
+/// An incoming update that grows the doc's delete set by at least this many
+/// clock units is logged. Clock units count operations, not characters - a
+/// character edited multiple times accumulates many clock units, so a small
+/// text deletion can produce a span in the hundreds. The forensic cases this
+/// targets (mass content reverts) are 5,000+ spans.
+const LARGE_DELETION_CLOCK_SPAN: u32 = 5000;
+
+fn deleted_spans_by_client<T: ReadTxn>(txn: &T) -> std::collections::HashMap<ClientID, u32> {
+    txn.snapshot()
+        .delete_set
+        .iter()
+        .map(|(client, ranges)| {
+            (
+                *client,
+                ranges.into_iter().map(|r| r.end - r.start).sum::<u32>(),
+            )
+        })
+        .collect()
+}
+
 pub struct DocConnection {
     awareness: Arc<RwLock<Awareness>>,
     #[allow(unused)] // acts as RAII guard
@@ -111,7 +131,13 @@ pub struct DocConnection {
 
     doc_id: Option<String>,
 
+    /// The doc's path within its shared folder, for log context only.
+    vpath: Option<String>,
+
     on_client_version: Option<ClientVersionCallback>,
+
+    /// Display name for `user`, for log context only.
+    user_name: Option<String>,
 }
 
 impl DocConnection {
@@ -262,6 +288,8 @@ impl DocConnection {
             sync_kv: None,
             user: None,
             doc_id: None,
+            vpath: None,
+            user_name: None,
         }
     }
 
@@ -281,6 +309,44 @@ impl DocConnection {
 
     pub fn set_on_client_version(&mut self, callback: ClientVersionCallback) {
         self.on_client_version = Some(callback);
+    }
+
+    pub fn set_vpath(&mut self, vpath: String) {
+        self.vpath = Some(vpath);
+    }
+
+    pub fn set_user_name(&mut self, user_name: String) {
+        self.user_name = Some(user_name);
+    }
+
+    fn log_large_deletion(
+        &self,
+        spans_before: &std::collections::HashMap<ClientID, u32>,
+        awareness: &Awareness,
+    ) {
+        let mut newly_deleted: Vec<(ClientID, u32)> =
+            deleted_spans_by_client(&awareness.doc().transact())
+                .into_iter()
+                .filter_map(|(client, span)| {
+                    let growth =
+                        span.saturating_sub(spans_before.get(&client).copied().unwrap_or(0));
+                    (growth > 0).then_some((client, growth))
+                })
+                .collect();
+        let deleted_clock_span: u32 = newly_deleted.iter().map(|(_, growth)| growth).sum();
+        if deleted_clock_span >= LARGE_DELETION_CLOCK_SPAN {
+            newly_deleted.sort_by_key(|(_, growth)| std::cmp::Reverse(*growth));
+            newly_deleted.truncate(10);
+            tracing::info!(
+                vpath = %self.vpath.as_deref().unwrap_or("-"),
+                name = %self.user_name.as_deref().unwrap_or("<none>"),
+                user = %self.user.as_deref().unwrap_or("-"),
+                deleted_clock_span,
+                doc_id = %self.doc_id.as_deref().unwrap_or("-"),
+                top_deleted_from = ?newly_deleted,
+                "Update applied a large deletion"
+            );
+        }
     }
 
     /// Snapshot the current state vector's client_ids (for before/after comparison).
@@ -431,10 +497,12 @@ impl DocConnection {
                     if can_write {
                         let mut awareness = a.write().unwrap();
                         let sv_before = self.snapshot_sv(&awareness);
+                        let ds_before = deleted_spans_by_client(&awareness.doc().transact());
                         let result =
                             protocol.handle_sync_step2(&mut awareness, Update::decode_v1(&update)?);
                         if result.is_ok() {
                             self.register_new_client_ids(&awareness, &sv_before);
+                            self.log_large_deletion(&ds_before, &awareness);
                         }
                         result
                     } else {
@@ -451,10 +519,12 @@ impl DocConnection {
                     if can_write {
                         let mut awareness = a.write().unwrap();
                         let sv_before = self.snapshot_sv(&awareness);
+                        let ds_before = deleted_spans_by_client(&awareness.doc().transact());
                         let result =
                             protocol.handle_update(&mut awareness, Update::decode_v1(&update)?);
                         if result.is_ok() {
                             self.register_new_client_ids(&awareness, &sv_before);
+                            self.log_large_deletion(&ds_before, &awareness);
                         }
                         result
                     } else {
@@ -1347,5 +1417,40 @@ mod tests {
         let result = connection.handle_msg(&DefaultProtocol, update);
         assert!(result.is_ok());
         assert!(result.unwrap().is_none());
+    }
+
+    #[test]
+    fn test_deleted_spans_by_client_growth_measures_removed_text() {
+        use yrs::{Doc, GetString, Text};
+
+        let doc = Doc::new();
+        let client = doc.client_id();
+        let text = doc.get_or_insert_text("t");
+        {
+            let mut txn = doc.transact_mut();
+            text.insert(&mut txn, 0, &"x".repeat(500));
+        }
+        let before = deleted_spans_by_client(&doc.transact());
+        assert_eq!(before.get(&client), None);
+        {
+            let mut txn = doc.transact_mut();
+            text.remove_range(&mut txn, 0, 300);
+            assert_eq!(text.get_string(&txn).len(), 200);
+        }
+        let after = deleted_spans_by_client(&doc.transact());
+        assert_eq!(after.get(&client), Some(&300));
+
+        {
+            let full_state = doc
+                .transact()
+                .encode_state_as_update_v1(&yrs::StateVector::default());
+            let mut txn = doc.transact_mut();
+            txn.apply_update(Update::decode_v1(&full_state).unwrap())
+                .unwrap();
+        }
+        assert_eq!(
+            deleted_spans_by_client(&doc.transact()).get(&client),
+            Some(&300)
+        );
     }
 }

--- a/crates/y-sweet-core/src/doc_connection.rs
+++ b/crates/y-sweet-core/src/doc_connection.rs
@@ -34,6 +34,51 @@ type Callback = Arc<dyn Fn(&[u8]) + 'static>;
 #[cfg(feature = "sync")]
 type Callback = Arc<dyn Fn(&[u8]) + 'static + Send + Sync>;
 
+/// Facts extracted from one awareness entry, before any trust decision.
+/// Everything here except `solo_live` comes from the entry's own state
+/// payload, which is minted by the entry's owner and survives relaying.
+pub struct AwarenessEntryFacts {
+    pub client_id: u64,
+    pub declared_version: Option<String>,
+    pub user_name: Option<String>,
+    pub user_id: Option<String>,
+    pub extra_client_ids: Vec<u64>,
+    pub solo_live: bool,
+}
+
+impl AwarenessEntryFacts {
+    fn from_entry(client_id: u64, json: &str, solo: bool) -> Self {
+        let live = json.trim() != "null";
+        let state = serde_json::from_str::<serde_json::Value>(json).ok();
+        let user = state.as_ref().and_then(|s| s.get("user"));
+        Self {
+            client_id,
+            declared_version: state
+                .as_ref()
+                .and_then(|s| s.get("relayVersion"))
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+            user_name: user
+                .and_then(|u| u.get("name"))
+                .and_then(|n| n.as_str())
+                .map(str::to_string),
+            user_id: user
+                .and_then(|u| u.get("id"))
+                .and_then(|i| i.as_str())
+                .map(str::to_string),
+            extra_client_ids: state
+                .as_ref()
+                .and_then(|s| s.get("relayClientIds"))
+                .and_then(|ids| ids.as_array())
+                .map(|ids| ids.iter().filter_map(|id| id.as_u64()).collect())
+                .unwrap_or_default(),
+            solo_live: solo && live,
+        }
+    }
+}
+
+type ClientVersionCallback = Box<dyn Fn(&AwarenessEntryFacts) + Send + Sync>;
+
 const SYNC_STATUS_MESSAGE: u8 = 102;
 
 pub struct DocConnection {
@@ -63,6 +108,10 @@ pub struct DocConnection {
     /// Authenticated user identity from the connection token.
     /// When set, the server will register new client_ids under this user in the "users" map.
     user: Option<String>,
+
+    doc_id: Option<String>,
+
+    on_client_version: Option<ClientVersionCallback>,
 }
 
 impl DocConnection {
@@ -206,11 +255,13 @@ impl DocConnection {
             authorization,
             callback,
             client_id: OnceLock::new(),
+            on_client_version: None,
             closed,
             event_subscriptions: Arc::new(RwLock::new(HashSet::new())),
             expiration_time,
             sync_kv: None,
             user: None,
+            doc_id: None,
         }
     }
 
@@ -222,6 +273,14 @@ impl DocConnection {
     /// Set the authenticated user identity for server-driven PUD registration.
     pub fn set_user(&mut self, user: String) {
         self.user = Some(user);
+    }
+
+    pub fn set_doc_id(&mut self, doc_id: String) {
+        self.doc_id = Some(doc_id);
+    }
+
+    pub fn set_on_client_version(&mut self, callback: ClientVersionCallback) {
+        self.on_client_version = Some(callback);
     }
 
     /// Snapshot the current state vector's client_ids (for before/after comparison).
@@ -240,11 +299,6 @@ impl DocConnection {
         awareness: &Awareness,
         sv_before: &std::collections::HashSet<ClientID>,
     ) {
-        let user_id = match &self.user {
-            Some(u) => u,
-            None => return,
-        };
-
         let sv_after = awareness.doc().transact().state_vector();
 
         let new_ids: Vec<ClientID> = sv_after
@@ -262,6 +316,10 @@ impl DocConnection {
             return;
         }
 
+        let Some(user_id) = &self.user else {
+            return;
+        };
+
         let doc = awareness.doc();
 
         for client_id in new_ids {
@@ -269,9 +327,7 @@ impl DocConnection {
         }
     }
 
-    /// Register a client_id in the "users" PermanentUserData map on the document.
-    /// Takes a Doc reference directly to avoid re-locking awareness.
-    fn register_pud_client_id_on_doc(doc: &yrs::Doc, user_id: &str, client_id: ClientID) {
+    pub fn register_pud_client_id_on_doc(doc: &yrs::Doc, user_id: &str, client_id: ClientID) {
         // get_or_insert_map takes a write txn internally, call before any read txn.
         let users_map = doc.get_or_insert_map("users");
 
@@ -417,11 +473,31 @@ impl DocConnection {
                 protocol.handle_awareness_query(&awareness)
             }
             Message::Awareness(update) => {
+                let solo = update.clients.len() == 1;
+                let facts: Vec<AwarenessEntryFacts> = update
+                    .clients
+                    .iter()
+                    .map(|(client_id, entry)| {
+                        AwarenessEntryFacts::from_entry(client_id.get(), &entry.json, solo)
+                    })
+                    .collect();
+                if let Some(callback) = &self.on_client_version {
+                    for entry_facts in &facts {
+                        callback(entry_facts);
+                    }
+                }
+                // PUD registration from payload user.id was here but caused a
+                // sync regression: the write lock + transact_mut per awareness
+                // message serialized against the sync path on reconnect. The
+                // cid upgrade path already registers declaring clients in PUD
+                // outside the message loop; delivery-time registration covers
+                // legacy clients. The awareness path was defense-in-depth only.
                 if update.clients.len() == 1 {
                     let client_id = update.clients.keys().next().unwrap();
                     self.client_id.get_or_init(|| *client_id);
                 } else {
                     tracing::warn!(
+                        doc_id = ?self.doc_id,
                         user = ?self.user,
                         connection_client_id = ?self.client_id.get(),
                         update_client_ids = ?update.clients.keys().collect::<Vec<_>>(),

--- a/crates/y-sweet-core/src/doc_sync.rs
+++ b/crates/y-sweet-core/src/doc_sync.rs
@@ -64,11 +64,18 @@ impl DocWithSyncKv {
                     // Extract the full snapshot from the transaction (post-update).
                     let snapshot = txn.snapshot().encode_v1();
 
+                    // A yrs Snapshot is a state vector plus delete set - a
+                    // marker, not content - so it cannot be decoded back into a
+                    // readable doc. Consumers that need to read the post-update
+                    // state get the encoded document instead.
+                    let state = txn.encode_state_as_update_v1(&StateVector::default());
+
                     // Create the event payload with business data, metadata, update, and snapshot
                     let event = DocumentUpdatedEvent::new(doc_key.clone())
                         .with_metadata(&sync_kv)
                         .with_update(event.update.to_vec())
-                        .with_snapshot(snapshot);
+                        .with_snapshot(snapshot)
+                        .with_state(state);
 
                     // Callback handles envelope creation and dispatch
                     callback(event);

--- a/crates/y-sweet-core/src/event.rs
+++ b/crates/y-sweet-core/src/event.rs
@@ -87,6 +87,12 @@ pub struct DocumentUpdatedEvent {
     pub update: Option<Vec<u8>>,
     #[serde(skip)] // Internal use only: encoded snapshot after this update
     pub snapshot: Option<Vec<u8>>,
+    /// The whole document encoded as an update, post-change. Unlike
+    /// `snapshot` (a yrs Snapshot: state vector + delete set - a marker, not
+    /// content) this can be decoded back into a readable doc, which is what a
+    /// consumer needs to inspect content without touching the live doc's lock.
+    #[serde(skip)]
+    pub state: Option<Vec<u8>>,
 }
 
 impl DocumentUpdatedEvent {
@@ -98,6 +104,7 @@ impl DocumentUpdatedEvent {
             metadata: BTreeMap::new(),
             update: None,
             snapshot: None,
+            state: None,
         }
     }
 
@@ -116,6 +123,12 @@ impl DocumentUpdatedEvent {
     /// Builder method to add encoded Yjs snapshot
     pub fn with_snapshot(mut self, snapshot: Vec<u8>) -> Self {
         self.snapshot = Some(snapshot);
+        self
+    }
+
+    /// Builder method to add the post-update document state
+    pub fn with_state(mut self, state: Vec<u8>) -> Self {
+        self.state = Some(state);
         self
     }
 


### PR DESCRIPTION
## Summary

Adds an opt-in `semantic_logging` mode (default off) that gives self-hosters visibility into who is editing what, without exposing user-identifying information unless explicitly configured.

When `semantic_logging = true` in relay.toml:

- **Edit attribution**: each content change is attributed to the user who made it (via PUD map resolution), not the connection that delivered it. Attribution comes only from an update's newly-created blocks; a pure deletion names no actor (see "Deletion attribution" below).
- **Keystroke debounce**: typing runs collapse into one logged burst rather than one line per keystroke. The first edit logs immediately; a summary with totals (edits, bytes, duration) follows once typing stops.
- **Vpath resolution**: log lines show the note's vault-relative path (e.g. `vpath=daily/2026-08-14.md`) instead of raw doc GUIDs.
- **Folder membership changes**: adds, removes, and renames within a shared folder are logged with the paths. Adds and renames name the acting user; removals carry `deleted_name`/`deleted_user`/`deleted_clients` - the owner of the removed entries, which is the only identity a deletion contains.
- **Large deletion detection**: updates that grow the delete set by 5000+ clock units are flagged - targets mass content reverts without alerting on normal editing.
- **`/client-versions` endpoint**: returns every known client-id-to-version binding as JSON. Server-auth required (Bearer token). Only mounted when `semantic_logging` is on.
- **Display names**: a `[server.user_names]` table maps relay user ids to human-readable names for log lines. Only consulted when `semantic_logging` is on.

When `semantic_logging = false` (default), the server behaves identically to the base (PR #23) - no names, no vpaths, no edit lines, no endpoint.

## Deletion attribution

A yjs update records who *wrote* blocks, never who *deleted* them: a deletion is a delete set of (client, clock) ranges, and those client ids are the ids of the deleted blocks' authors. Reading the delete set as "the actor" therefore blames the original writer for someone else's deletion - one person's bulk cleanup of stale files was logged as three different users, each the file's last writer, before this was caught.

So the rules here are:

- Actors (`user=`/`name=`/`clients=`) are resolved from newly-created blocks only. A move (remove + insert in one transaction) still attributes to the mover through its inserted block.
- A delete-only update logs `user=-`: the deleting client is genuinely not present in the update.
- Membership removals additionally log `deleted_user`/`deleted_name`/`deleted_clients`, naming whose entries were removed.
- The captured first-load identity is used as a fallback only for updates that delete nothing, since a deletion's actor is unknown rather than merely unregistered.

## New modules

- `edit_bursts.rs` - keystroke collapse with configurable quiet period (10s default)
- `vpath_index.rs` - cached GUID-to-path resolution from folder `filemeta_v0` maps

## Configuration

```toml
[server]
semantic_logging = true

[server.user_names]
"abc123" = "Ada Lovelace"
```

## Relationship to the other open PRs

Depends on #23, which is the one real dependency in this set: `client_versions.declare()` takes the display name added there, `AwarenessEntryFacts` is defined there, and the edit-attribution path reads the PUD registrations it introduces. Cross-fork branches can't be a GitHub base, so this targets `main` and the diff includes #23's commit - review only `feat: semantic logging - edit attribution, debounce, vpath resolution, and /client-versions`.

| PR | Contains | Independent? |
|---|---|---|
| #26 | log volume: demotions, connection lifecycle logs, identity on warns | yes |
| #23 | behavior: version gating, cid declarations, PUD suppression | yes |
| **#24 (this one)** | semantic logging, gated on a config flag that defaults to off | no - needs #23 |
| #25 | attributed-content endpoint | yes |

This PR changes no log levels; the demotions it once carried are in #26.

## Test plan

- [ ] Verify no edit/vpath/name logging when `semantic_logging` is false (default)
- [ ] Verify `Doc edited` lines with correct vpath and user attribution when enabled
- [ ] Verify keystroke debounce collapses a typing run into leading + summary
- [ ] Verify folder membership changes log adds/removes/renames
- [ ] Verify removing another client's entry logs `user=-` and names the entry's owner under `deleted_user` (regression-tested in `edit_author.rs`)
- [ ] Verify `/client-versions` returns 404 when `semantic_logging` is false
- [ ] Verify `/client-versions` requires server auth when enabled
- [ ] Verify large deletion detection fires at 5000+ clock span
- [ ] 296 tests pass



