### PR TITLE
feat: attributed-content endpoint for per-span doc authorship

### DIFF
--- a/crates/relay/src/attributed_content.rs
+++ b/crates/relay/src/attributed_content.rs
@@ -1,0 +1,254 @@
+//! Per-span authorship of a doc's current text content.
+//!
+//! Every yjs item structurally carries the client ID that created it, and the
+//! server-driven PUD "users" map records which user each client ID belongs to.
+//! Combining the two attributes every surviving character of a text root to a
+//! user - the basis for per-author git commits downstream (git-sync).
+
+use std::collections::HashMap;
+
+use serde::Serialize;
+use yrs::types::text::YChange;
+use yrs::updates::decoder::Decode;
+use yrs::{Array, GetString, Map, Out, ReadTxn, Snapshot, StateVector, Text, Transact, Update};
+
+#[derive(Serialize, Debug, PartialEq)]
+pub struct AttributedSpan {
+    pub text: String,
+    /// None only in the fallback case where attribution could not be computed.
+    pub client_id: Option<u64>,
+    pub user: Option<String>,
+}
+
+#[derive(Serialize, Debug)]
+pub struct AttributedContent {
+    pub root: String,
+    pub spans: Vec<AttributedSpan>,
+}
+
+/// Reverse the PUD "users" map (user -> {ids: [client_id]}) into client -> user.
+pub fn user_by_client<T: ReadTxn>(txn: &T) -> HashMap<u64, String> {
+    let mut result = HashMap::new();
+    let Some(users_map) = txn.get_map("users") else {
+        return result;
+    };
+
+    for (user_id, user_val) in users_map.iter(txn) {
+        let Out::YMap(user_map) = user_val else {
+            continue;
+        };
+        let Some(Out::YArray(ids_arr)) = user_map.get(txn, "ids") else {
+            continue;
+        };
+        for item in ids_arr.iter(txn) {
+            let client_id = match item {
+                Out::Any(yrs::Any::Number(n)) => Some(n as u64),
+                Out::Any(yrs::Any::BigInt(n)) => Some(n as u64),
+                _ => None,
+            };
+            if let Some(cid) = client_id {
+                result.insert(cid, user_id.to_string());
+            }
+        }
+    }
+    result
+}
+
+fn _attributed_spans(
+    doc: &yrs::Doc,
+    root: &str,
+    users: &HashMap<u64, String>,
+) -> Vec<AttributedSpan> {
+    let mut txn = doc.transact_mut();
+    let text = txn.get_text(root).expect("checked by caller");
+
+    // With hi = the current snapshot and lo = an empty one, every visible item
+    // is "added" between the snapshots, so each chunk carries its item's ID.
+    let current = txn.snapshot();
+    let chunks = text.diff_range(
+        &mut txn,
+        Some(&current),
+        Some(&Snapshot::default()),
+        YChange::identity,
+    );
+
+    let mut spans: Vec<AttributedSpan> = Vec::new();
+    for chunk in chunks {
+        let piece = match &chunk.insert {
+            Out::Any(yrs::Any::String(s)) => s.to_string(),
+            _ => continue,
+        };
+        let client_id = match &chunk.ychange {
+            Some(change) => change.id.client.get(),
+            None => continue,
+        };
+        match spans.last_mut() {
+            Some(last) if last.client_id == Some(client_id) => last.text.push_str(&piece),
+            _ => spans.push(AttributedSpan {
+                text: piece,
+                client_id: Some(client_id),
+                user: users.get(&client_id).cloned(),
+            }),
+        }
+    }
+    spans
+}
+
+/// The current visible content of the named text root, split into spans by
+/// authoring client, with clients resolved to users via the PUD "users" map.
+/// Returns None if the doc has no such text root.
+///
+/// The walk runs on a throwaway clone of the doc: diff_range splits blocks in
+/// place (so the live doc must not be touched), and yrs 0.26 panics with a
+/// divide-by-zero in find_pivot when splitting at the current snapshot while
+/// any client's stream is a single one-unit block. On that panic the clone is
+/// discarded and the whole content is returned as one unattributed span.
+pub fn attributed_content(doc: &yrs::Doc, root: &str) -> Option<AttributedContent> {
+    let full_state = doc
+        .transact()
+        .encode_state_as_update_v1(&StateVector::default());
+    let clone = yrs::Doc::new();
+    clone
+        .transact_mut()
+        .apply_update(Update::decode_v1(&full_state).ok()?)
+        .ok()?;
+
+    let full_text = {
+        let txn = clone.transact();
+        txn.get_text(root)?.get_string(&txn)
+    };
+    let users = user_by_client(&clone.transact());
+
+    let spans = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        _attributed_spans(&clone, root, &users)
+    })) {
+        Ok(spans) => spans,
+        Err(_) => {
+            tracing::warn!(
+                root,
+                "attribution walk panicked; returning unattributed content"
+            );
+            vec![AttributedSpan {
+                text: full_text,
+                client_id: None,
+                user: None,
+            }]
+        }
+    };
+
+    Some(AttributedContent {
+        root: root.to_string(),
+        spans,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use yrs::Doc;
+
+    fn sync(from: &Doc, to: &Doc) {
+        let sv = to.transact().state_vector();
+        let update = from.transact().encode_state_as_update_v1(&sv);
+        to.transact_mut()
+            .apply_update(Update::decode_v1(&update).unwrap())
+            .unwrap();
+    }
+
+    fn register_user(doc: &Doc, user: &str, client_id: u64) {
+        let users_map = doc.get_or_insert_map("users");
+        let mut txn = doc.transact_mut();
+        let user_map = users_map.insert(&mut txn, user, yrs::MapPrelim::default());
+        let ids = user_map.insert(&mut txn, "ids", yrs::ArrayPrelim::default());
+        ids.push_back(&mut txn, yrs::Any::Number(client_id as f64));
+    }
+
+    #[test]
+    fn test_two_authors_attributed_and_merged() {
+        let alice = Doc::new();
+        let bob = Doc::new();
+        alice.get_or_insert_text("contents");
+        bob.get_or_insert_text("contents");
+
+        {
+            let text = alice.get_or_insert_text("contents");
+            let mut txn = alice.transact_mut();
+            text.insert(&mut txn, 0, "hello world");
+        }
+        sync(&alice, &bob);
+        {
+            let text = bob.get_or_insert_text("contents");
+            let mut txn = bob.transact_mut();
+            text.insert(&mut txn, 5, " there,");
+        }
+        sync(&bob, &alice);
+        register_user(&alice, "alice-user", alice.client_id().get());
+        register_user(&alice, "bob-user", bob.client_id().get());
+
+        let content = attributed_content(&alice, "contents").unwrap();
+        let full: String = content.spans.iter().map(|s| s.text.as_str()).collect();
+        assert_eq!(full, "hello there, world");
+        assert_eq!(content.spans.len(), 3);
+        assert_eq!(content.spans[0].user.as_deref(), Some("alice-user"));
+        assert_eq!(content.spans[0].text, "hello");
+        assert_eq!(content.spans[1].user.as_deref(), Some("bob-user"));
+        assert_eq!(content.spans[1].text, " there,");
+        assert_eq!(content.spans[2].user.as_deref(), Some("alice-user"));
+        assert_eq!(content.spans[2].text, " world");
+    }
+
+    #[test]
+    fn test_deletion_leaves_survivors_attributed() {
+        let doc = Doc::new();
+        let text = doc.get_or_insert_text("contents");
+        {
+            let mut txn = doc.transact_mut();
+            text.insert(&mut txn, 0, "abcdef");
+            text.remove_range(&mut txn, 1, 3);
+        }
+
+        let content = attributed_content(&doc, "contents").unwrap();
+        let full: String = content.spans.iter().map(|s| s.text.as_str()).collect();
+        assert_eq!(full, "aef");
+        assert!(content
+            .spans
+            .iter()
+            .all(|s| s.client_id == Some(doc.client_id().get()) && s.user.is_none()));
+    }
+
+    #[test]
+    fn test_missing_root_returns_none() {
+        let doc = Doc::new();
+        assert!(attributed_content(&doc, "contents").is_none());
+    }
+
+    #[test]
+    fn test_unmapped_client_has_null_user() {
+        let doc = Doc::new();
+        let text = doc.get_or_insert_text("contents");
+        {
+            let mut txn = doc.transact_mut();
+            text.insert(&mut txn, 0, "xy");
+        }
+        let content = attributed_content(&doc, "contents").unwrap();
+        assert_eq!(content.spans[0].user, None);
+        assert_eq!(content.spans[0].client_id, Some(doc.client_id().get()));
+    }
+
+    /// A client whose whole stream is one single-unit block triggers a panic
+    /// in yrs 0.26's find_index (clock / 0) when splitting at the current
+    /// snapshot. The catch_unwind fallback returns the full text as one
+    /// unattributed span rather than crashing.
+    #[test]
+    fn test_single_unit_stream_falls_back_gracefully() {
+        let doc = Doc::new();
+        let text = doc.get_or_insert_text("contents");
+        {
+            let mut txn = doc.transact_mut();
+            text.insert(&mut txn, 0, "x");
+        }
+        let content = attributed_content(&doc, "contents").unwrap();
+        assert_eq!(content.spans.len(), 1);
+        assert_eq!(content.spans[0].text, "x");
+    }
+}

--- a/crates/relay/src/lib.rs
+++ b/crates/relay/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../README.md")]
 
+pub mod attributed_content;
 pub mod cli;
 pub mod convert;
 pub mod doc_inspect;

--- a/crates/relay/src/server.rs
+++ b/crates/relay/src/server.rs
@@ -750,6 +750,10 @@ impl Server {
             .route("/doc/:doc_id/as-update", get(get_doc_as_update_deprecated))
             .route("/doc/:doc_id/update", post(update_doc_deprecated))
             .route("/d/:doc_id/as-update", get(get_doc_as_update))
+            .route(
+                "/d/:doc_id/attributed-content",
+                get(get_doc_attributed_content),
+            )
             .route("/d/:doc_id/update", post(update_doc))
             .route("/d/:doc_id/versions", get(handle_doc_versions))
             .route(
@@ -912,6 +916,41 @@ async fn get_doc_as_update_deprecated(
 ) -> Result<Response, AppError> {
     tracing::warn!("/doc/:doc_id/as-update is deprecated; call /doc/:doc_id/auth instead and then call as-update on the returned base URL.");
     get_doc_as_update(State(server_state), Path(doc_id), auth_header).await
+}
+
+#[derive(Deserialize)]
+struct AttributedContentParams {
+    root: Option<String>,
+}
+
+async fn get_doc_attributed_content(
+    State(server_state): State<Arc<Server>>,
+    Path(doc_id): Path<String>,
+    Query(params): Query<AttributedContentParams>,
+    auth_header: Option<TypedHeader<headers::Authorization<headers::authorization::Bearer>>>,
+) -> Result<Response, AppError> {
+    server_state.check_auth(auth_header)?;
+
+    let guard = server_state
+        .attach_doc(&doc_id, AttachKind::Http, None, None)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+
+    let root = params.root.as_deref().unwrap_or("contents");
+    let awareness = guard.awareness();
+    let awareness = awareness.read().unwrap();
+    match crate::attributed_content::attributed_content(awareness.doc(), root) {
+        Some(content) => Ok(Json(json!({
+            "doc_id": doc_id,
+            "root": content.root,
+            "spans": content.spans,
+        }))
+        .into_response()),
+        None => Err(AppError::new(
+            StatusCode::NOT_FOUND,
+            anyhow!("doc has no text root named {root}"),
+        )),
+    }
 }
 
 async fn update_doc_deprecated(


### PR DESCRIPTION
## Summary

Adds a `GET /d/:doc_id/attributed-content` endpoint that returns the current visible text content of a document, split into spans by authoring client, with clients resolved to users via the PermanentUserData "users" map.

This enables downstream consumers (e.g. a git-sync server) to produce per-author commits from collaborative documents.

## Auth

The endpoint requires server auth (`Y_SWEET_AUTH` Bearer token) - the same auth used by `/check_store` and other admin endpoints. This is intentionally more restrictive than doc-token auth since the endpoint exposes content and authorship information that is appropriate for server-to-server use, not end-user access.

## API

```
GET /d/:doc_id/attributed-content?root=contents
Authorization: Bearer <Y_SWEET_AUTH>
```

Response:
```json
{
  "doc_id": "abc123",
  "root": "contents",
  "spans": [
    {"text": "hello", "client_id": 42, "user": "alice"},
    {"text": " world", "client_id": 99, "user": "bob"}
  ]
}
```

The `root` query param defaults to `"contents"` (the standard text root for Relay documents). Returns 404 if the doc has no text root by that name.

## Implementation

The attribution walk runs on a cloned doc (not the live one) to avoid mutating shared state. It uses `diff_range` between the current snapshot and an empty snapshot, which surfaces every visible item with its originating client ID. Adjacent characters from the same client are merged into a single span.

A `catch_unwind` guard handles a known yrs 0.26 panic in `find_pivot` when splitting at the current snapshot while a client's stream is a single one-unit block - in that case the full content is returned as one unattributed span.

That panic is a divide-by-zero in `find_index` (`block_store.rs`), which I filed upstream as [y-crdt/y-crdt#645](https://github.com/y-crdt/y-crdt/pull/645); it was closed in favor of [#647](https://github.com/y-crdt/y-crdt/pull/647), which fixes part of the same problem. Neither is in a crates.io release, so on our own deployment we pin a fork carrying the fix on top of the `dtkav/y-crdt` revision this repo already uses: `petergaultney/y-crdt` rev `4996719` (branch `thds/0.26.0-patched`).

The `catch_unwind` in this PR is deliberately the whole remedy here - it degrades to one unattributed span rather than requiring a patched yrs, so this PR needs no dependency change. If you would rather take the yrs pin instead and drop the guard, that works too, but it means carrying a fork of yrs.

## Relationship to the other open PRs

Independent of the logging/behavior split (#26, #23, #24) - no overlapping hunks, any merge order works.

Companion PR: [No-Instructions/relay-git-sync#6](https://github.com/No-Instructions/relay-git-sync/pull/6) consumes this endpoint to produce per-author commits. That PR degrades gracefully when the endpoint is absent or returns 401/404, so it does not have to merge after this one.

## Test plan

- [ ] Verify endpoint requires server auth (401 without Bearer token)
- [ ] Verify two-author attribution after sync
- [ ] Verify deletions leave surviving spans attributed
- [ ] Verify missing text root returns 404
- [ ] Verify unmapped clients have null user
- [ ] 242 tests pass
